### PR TITLE
Fix formatting of the lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,25 +25,25 @@ Thus, FLEXIcontent was designed to manage content in a broad sense:
 - etc
 within a single user interface.
 
--- This means for the end user, unparalleled simplicity of use, everything happens in one place.
--- Mastering 10 components to be able to administrate an entire website isn’t required anymore.
--- For the web designer / end user / developer, it means a lot less headaches of interoperability/maintenance
+-- This means for the end user, unparalleled simplicity of use, everything happens in one place.  
+-- Mastering 10 components to be able to administrate an entire website isn’t required anymore.  
+-- For the web designer / end user / developer, it means a lot less headaches of interoperability/maintenance  
 
-Some of FLEXIcontent Unique features:
+Some of FLEXIcontent Unique features:  
 (none in other component's Free versions, many unique compared to commercial versions)
 
--- Multi Category assigments, with multiple featured categories (configurable via our Advance Route Plugin, see our FAQ)
--- Multiple Document versioning (combined with workflow and powerful notifications messages, see below)
--- Multi-state Workflow to assist both editors & publishers to add/update content to your site
--- Highly configurable powerful notification system: (Global) Component + Per Content Type + Per category
--- High parametrized Fields(=joomla plugin each) (carefully structured to assist configuration and be performance wise)
--- Powerful relation/reverse Relation fields to create custom Content Item sub-listing inside a Content Item
--- An powerful image/gallery field to create DB-reusable image/galleries or item-field specific galleries with numerous parameterization options
--- Multiple filter apperances: text field/single select/dual text range/dual select range/toggle radio/toggle checkbox(multiple filter values)
--- FACETED filter behavior for almost all searchable fields: showing filter values according to current filtering and current
--- A -Free- Advanced Search view (to host the above 2, but also available in categories too) and create content-rich listings
--- Directory/Catalog features, directory view + a powerful Alpha-Index with character aliases, character aggregations, language customizations
--- Selective plugin triggering in all fields
--- High performance frontend views and items manager, with steady performance as sites grows (**installing on EXISTING larges sites 20,000+ items is still slow, TODO), (and works with full page caching extensions)
--- 30+ ACL actions (e.g. edit field value)
--- ... many more UNIQUE
+-- Multi Category assigments, with multiple featured categories (configurable via our Advance Route Plugin, see our FAQ)  
+-- Multiple Document versioning (combined with workflow and powerful notifications messages, see below)  
+-- Multi-state Workflow to assist both editors & publishers to add/update content to your site  
+-- Highly configurable powerful notification system: (Global) Component + Per Content Type + Per category  
+-- High parametrized Fields(=joomla plugin each) (carefully structured to assist configuration and be performance wise)  
+-- Powerful relation/reverse Relation fields to create custom Content Item sub-listing inside a Content Item  
+-- An powerful image/gallery field to create DB-reusable image/galleries or item-field specific galleries with numerous parameterization options  
+-- Multiple filter apperances: text field/single select/dual text range/dual select range/toggle radio/toggle checkbox(multiple filter values)  
+-- FACETED filter behavior for almost all searchable fields: showing filter values according to current filtering and current  
+-- A -Free- Advanced Search view (to host the above 2, but also available in categories too) and create content-rich listings  
+-- Directory/Catalog features, directory view + a powerful Alpha-Index with character aliases, character aggregations, language customizations  
+-- Selective plugin triggering in all fields  
+-- High performance frontend views and items manager, with steady performance as sites grows (**installing on EXISTING larges sites 20,000+ items is still slow, TODO), (and works with full page caching extensions)  
+-- 30+ ACL actions (e.g. edit field value)  
+-- ... many more UNIQUE  


### PR DESCRIPTION
ADDED extra spaces at end of lines
In markdown you need "  " two extra spaces at the end of a line with only a line break not two returns or the formatting wraps. This meant you could not see the points on github, they all went into a paragraph.
