### PR TITLE
Update en-GB.com_flexicontent.ini

### DIFF
--- a/site/language/en-GB.com_flexicontent.ini
+++ b/site/language/en-GB.com_flexicontent.ini
@@ -323,7 +323,7 @@ FLEXI_ARCHIVE_THIS_ITEM="Set state as : archived"
 FLEXI_TRASH_THIS_ITEM="Set state as : trashed"
 
 FLEXI_CLICK_TO_CHANGE_STATE="<small>- CLICK to change state of the item</small>"
-FLEXI_STATE_CHANGER_DISABLED="<small>- Popup State Changer Disabled (e.g too many items listed per page)</small>"
+FLEXI_STATE_CHANGER_DISABLED="<small>- Popup State Changer Disabled (Set display to 30 items or less)</small>"
 
 FLEXI_START="Start"
 FLEXI_FINISH="Finish"


### PR DESCRIPTION
I thought this was a bug but being more specific that you need to change the display to 30 items or less would be infinitely more helpful. As even if you have only 10 items - it doesn't work if the column is set to 50.

![image](https://cloud.githubusercontent.com/assets/8617673/4859395/9138ada8-60e9-11e4-9e22-7bf48741f9be.png)
