### PR TITLE
Form action not updated with selected autocomplete value

### DIFF
--- a/site/assets/js/tmpl-common.js
+++ b/site/assets/js/tmpl-common.js
@@ -346,6 +346,7 @@ jQuery(document).ready(function() {
 			minLength: 1,
 			select: function( event, ui ) {
 				//console.log( ui.item  ?  "Selected: " + ui.item.label  :  "Nothing selected, input was " + this.value);
+				if ( ui.item ) this.value = ui.item.label.trim();
 				var ele = event.target;
 				jQuery(ele).trigger('change');
 			},


### PR DESCRIPTION
The problem is that the form element value is still with the old value when the form action gets updated. For instance, if we type the words "exa" and select (with the mouse because with the keyboard works okay) the word "example" from the autocomplete list, the form action becomes "searchword= exa". There is also an additional (and unnecessary) white space next to the equal sign that is trimmed now.