### PR TITLE
Make target categories selector for copy parameters pop to fit without scrolling

### DIFF
--- a/admin/views/categories/view.html.php
+++ b/admin/views/categories/view.html.php
@@ -237,7 +237,7 @@ class FlexicontentViewCategories extends JViewLegacy
 		
 		$categories = & $globalcats;
 		$lists['copyid'] = flexicontent_cats::buildcatselect($categories, 'copycid', '', 2, 'class="inputbox"', false, true, $actions_allowed=array('core.edit'));
-		$lists['destid'] = flexicontent_cats::buildcatselect($categories, 'destcid[]', '', false, 'class="inputbox" size="15" multiple="true"', false, true, $actions_allowed=array('core.edit'));
+		$lists['destid'] = flexicontent_cats::buildcatselect($categories, 'destcid[]', '', false, 'class="inputbox" size="10" multiple="true"', false, true, $actions_allowed=array('core.edit'));
 		
 		
 		// *******************


### PR DESCRIPTION
15 columns I feel is too long for the squeeze block - as you need to scroll to apply the change