### PR TITLE
Modal Popup doesn't work

### DIFF
--- a/admin/views/fields/view.html.php
+++ b/admin/views/fields/view.html.php
@@ -144,12 +144,12 @@ class FlexicontentViewFields extends JViewLegacy
 				$btn_task, $extra_js, $btn_list=true, $btn_menu=true, $btn_confirm=false, $btn_class="");
 			
 			$js .= "
-				jQuery('#toolbar-basicindex a.toolbar, #toolbar-basicindex button')
+				jQuery('#toolbar-basicindex a.toolbar, #toolbar-basicindex button, a.modal')
 					.attr('onclick', 'javascript:;')
 					.attr('href', '".$popup_load_url."')
 					.attr('rel', '{handler: \'iframe\', size: {x: 800, y: 340}, onClose: function() {}}');
 			";
-			JHtml::_('behavior.modal', '#toolbar-basicindex a.toolbar, #toolbar-basicindex button');
+			JHtml::_('behavior.modal', '#toolbar-basicindex a.toolbar, #toolbar-basicindex button, a.modal');
 		}
 		
 		$contrl = "fields.";


### PR DESCRIPTION
1. The language file uses a.modal - but the  #toolbar-basicindex a.toolbar isn't called by the language file.

But - changing the value doesn't seem to make it work. a.modal creates a popup - but the wrong type of popup. 

![image](https://cloud.githubusercontent.com/assets/8617673/9156527/3084c2fc-3f10-11e5-8f20-2ad036aae578.png)


