### PR TITLE
Message in fields manager has a shortcut link to search indexer, but modal Popup doesn't work

### DIFF
--- a/admin/views/fields/tmpl/default.php
+++ b/admin/views/fields/tmpl/default.php
@@ -118,6 +118,17 @@ function delAllFilters() {
 
 </script>
 
+<script>
+		jQuery(function($) {
+			SqueezeBox.initialize({});
+			SqueezeBox.assign($('a.modal').get(), {
+				parse: 'rel'
+			});
+		});
+		function jModalClose() {
+			SqueezeBox.close();
+		}
+</script>
 <div class="flexicontent">
 
 <form action="index.php?option=<?php echo $this->option; ?>&view=<?php echo $this->view; ?>" method="post" name="adminForm" id="adminForm">


### PR DESCRIPTION
1. The language file for basic search indexer and advanced uses a.modal - but its not called on the page.