### PR TITLE
Update en-GB.com_flexicontent.ini

### DIFF
--- a/admin/language/en-GB/en-GB.com_flexicontent.ini
+++ b/admin/language/en-GB/en-GB.com_flexicontent.ini
@@ -96,6 +96,7 @@ FLEXI_SELECT_STATE="Select state"
 FLEXI_UNPUBLISHED="Unpublished"
 FLEXI_SELECT_AUTHOR="Select author"
 FLEXI_SELECT_CAT="Select category"
+FLEXI_SELECT_CATEGORY="Select category"
 FLEXI_SELECT_TYPE="Select type"
 FLEXI_ALTLINK_TEXTE="Alternative Read more text"
 


### PR DESCRIPTION
The language string for association in 
index.php?option=com_flexicontent&view=category&layout=edit&id=54&extension=com_flexicontent
is missing
not sure if you are renaming it to FLEXI_SELECT_CAT