### PR TITLE
Update flexicontentbackend.css

### DIFF
--- a/admin/assets/css/flexicontentbackend.css
+++ b/admin/assets/css/flexicontentbackend.css
@@ -3788,3 +3788,5 @@ ul.import-failed li {
 	min-width: 50px;
 	box-sizing: border-box;
 }
+/**/
+.admintable .row {margin-left: 0 !important;}


### PR DESCRIPTION
.row is used by bootstrap and has a negative left margin - I am finding that because I'm using .row in my code its showing weirdly the tables overlap:

http://imgur.com/a/Kyfxv

Perhaps as a .row shouldn't be inside a table - you can use the following code or be more specific.