### PR TITLE
Use user defined Category field name in form

### DIFF
--- a/site/views/item/tmpl/form.php
+++ b/site/views/item/tmpl/form.php
@@ -697,7 +697,12 @@ if ( $typeid && $this->params->get('allow_subscribers_notify_fe', 0) && $this->s
 if ( !$this->menuCats || $this->menuCats->cancatid) : ob_start();  // category ?>
 	<span class="label-fcouter" id="jform_catid-lbl-outer">
 		<label id="jform_catid-lbl" for="jform_catid" data-for="jform_catid" class="<?php echo $lbl_class; ?>">
-			<?php echo JText::_( !$secondary_displayed || isset($all_tab_fields['category']) ? 'FLEXICONTENT_CATEGORY' : 'FLEXI_MAIN_CATEGORY' ); ?>
+			<?php 
+			if ($field->label=='Categories')
+				{echo JText::_( !$secondary_displayed || isset($all_tab_fields['category']) ? 'FLEXICONTENT_CATEGORY' : 'FLEXI_MAIN_CATEGORY' ); }
+			else
+				{echo JText::_( !$secondary_displayed || isset($all_tab_fields['category']) ? $field->label : 'FLEXI_MAIN_CATEGORY' ); }
+			?>
 		</label>
 	</span>
 	


### PR DESCRIPTION
If Category field name is same as default 'Categories' display language defined FLEXICONTENT_CATEGORY (or language override from Joomla). Otherwise use user defined [default]= or laguage [en]=, [fr]=, ....