### PR TITLE
Update default.php

### DIFF
--- a/admin/views/category/tmpl/default.php
+++ b/admin/views/category/tmpl/default.php
@@ -75,7 +75,7 @@ $this->document->addScriptDeclaration($js);
 			<div class="container-fluid" style="padding: 0px !important;">
 
 				<!--LEFT COLUMN-->
-				<div class="span6 full_width_980 off-white" style="max-width: 640px;">
+				<div class="span6 full_width_980" style="max-width: 640px;">
 
 					<div>
 
@@ -121,7 +121,7 @@ $this->document->addScriptDeclaration($js);
 
 
 				<!--RIGHT COLUMN-->
-				<div class="span6 full_width_980 off-white">
+				<div class="span6 full_width_980 off-white pull-right">
 
 				<!--START RIGHT ACCORDION-->
 				<?php echo JHtml::_('bootstrap.startAccordion', 'right-accordion-1', array('active' => 'none', 'parent' => 'right-accordion-1')); ?>


### PR DESCRIPTION
Sorry - the https://github.com/FLEXIcontent/flexicontent-cck/tree/cat_tmpl is closed:

css changes suggested:
.off-white {background:#fafafa;}

#flexicontent .form-inline.form-inline-header .control-label {
	text-align: left;
	width: auto;
	display: block;
}
#flexicontent .form-inline.form-inline-header .controls {
	margin-left: 0;
	display: inline-block;
	padding-right: 5px;
}

For me, I kind of like it all aligned left- its easier on the eyes:
https://imgur.com/p7S7LjE

Do you think Category Notes - rather than being under images tab - put in publishing?

Joomla Categories/Articles has the description span9 > span 3:
https://imgur.com/c6Spsyu

It might be more realistic for the client as most frontend templates limit the width to 1200px width.

Also perhaps tabber could be simplified - and should start on the left - rather than having the first margin - more like Joomla Tabs - which I did in the code above. LMK and I will submit changes to tabber.css