### PR TITLE
Update flexi_backend.less

### DIFF
--- a/admin/assets/less/flexi_backend.less
+++ b/admin/assets/less/flexi_backend.less
@@ -1161,3 +1161,20 @@ img.btn.btn-small.fc-man-icon-s {
 body .j-sidebar-container {
 	padding-bottom: 36px;
 }
+	
+	
+/*
+ *	=======================================================================
+	+ FLEXICONTENT | TYPES VIEW
+ *	=======================================================================
+ */
+.view-types {
+@media (max-width: 979px){
+	#columnchoose_adminListTableFCtypes_3_label, #columnchoose_adminListTableFCtypes_10_label, #columnchoose_adminListTableFCtypes_5_label 
+	{display: none !important;}	
+}
+
+@media (max-width: 767px) {
+	#columnchoose_adminListTableFCtypes_4_label, #columnchoose_adminListTableFCtypes_9_label {display: none !important;}	
+	}
+}


### PR DESCRIPTION
As the tables are now responsive using hidden-tablet and hidden-phone - the columns filters don't match the hidden areas:

https://imgur.com/aiwWakR

Perhaps also hiding the column box as well for small would simplify it.
````
<span id="fc_mainChooseColBox_btn" class="<?php echo $_class; ?> hidden-phone" onclick="fc_toggle_box_via_btn('mainChooseColBox', this, 'btn-primary');">
<?php echo JText::_( 'FLEXI_COLUMNS' ); ?><sup id="columnchoose_totals"></sup>
</span> 
````