### PR TITLE
Improved Crowdin-GitHub configuration file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,5 +2,5 @@ files:
   - source: /**/en-GB/*.ini
     translation: /**/%locale%/%locale%.%file_name%.ini
     translation_replace: {
-    "en-GB" : ""
+    "en-GB." : ""
 }

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,6 @@
 files:
   - source: /**/en-GB/*.ini
     translation: /**/%locale%/%locale%.%file_name%.ini
+    translation_replace: {
+    "en-GB" : ""
+}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,3 @@
 files:
-  - source: '*.ini'
-    translation: >-
-      /%original_path%/%two_letters_code%/%two_letters_code%_%original_file_name%.%file_extension%
+  - source: /**/en-GB/*.ini
+    translation: /**/%locale%/%locale%.%file_name%.ini


### PR DESCRIPTION
I've applied "translation_replace" to remove en-GB prefix from your exported files:
https://support.crowdin.com/configuration-file/#renaming-translations-file

If you prefer to export languages like French and Spanish as **fr** and **es** accordingly. I'll help, just need to understand your expectations:
https://support.crowdin.com/configuration-file/#language-mapping

After accepting my PR, please Pause and Resume the integration in Crowdin to apply changes