### PR TITLE
Improvements to phone number field

### DIFF
--- a/plugins/flexicontent_fields/phonenumbers/phonenumbers.php
+++ b/plugins/flexicontent_fields/phonenumbers/phonenumbers.php
@@ -434,9 +434,10 @@ class plgFlexicontent_fieldsPhonenumbers extends FCField
 						. $value['phone2'] . $value['phone3']
 						. '">';
 			}
-			$html .= ($display_country_code ? $country_code_prefix . $value['cc'] . $separator_cc_phone1 : '')
-					. ($display_area_code    ? $value['phone1'] . $separator_phone1_phone2 : '')
-					. $value['phone2'] . $separator_phone2_phone3 . $value['phone3']
+			$html .= ($display_country_code ? $country_code_prefix . $value['cc'] : '')
+					. ($display_country_code || $display_area_code ? $separator_cc_phone1 : '')
+					. ($display_area_code ? $value['phone1'] : '')
+					. $separator_phone1_phone2 . $value['phone2'] . $separator_phone2_phone3 . $value['phone3']
 					. ($add_tel_link ? '</a>' : '')
 					. $closetag;
 

--- a/plugins/flexicontent_fields/phonenumbers/phonenumbers.xml
+++ b/plugins/flexicontent_fields/phonenumbers/phonenumbers.xml
@@ -151,12 +151,12 @@
 			<field name="label_suffix" type="text" default="" size="10" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_LABEL_SUFFIX" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_LABEL_SUFFIX_DESC" />
 			
 			<field name="" type="separator" default="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_CODE" description="" level="level3" />
-			<field name="country_code_prefix" type="text" default="+" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_CODE_PREFIX" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_CODE_PREFIX_DESC" />
-			<field name="separator_cc_phone1" type="text" default=" " size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_AREA_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_AREA_SEP_DESC" />
+			<field name="country_code_prefix" type="text" default="" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_CODE_PREFIX" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_CODE_PREFIX_DESC" />
+			<field name="separator_cc_phone1" type="text" default="" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_AREA_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_COUNTRY_AREA_SEP_DESC" />
 			
 			<field name="" type="separator" default="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_PHONE_NUMBER" description="" level="level3" />
-			<field name="separator_phone1_phone2" type="text" default="-" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_AREA_PART2_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_AREA_PART2_SEP_DESC" />
-			<field name="separator_phone2_phone3" type="text" default="-" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_PART2_PART3_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_PART2_PART3_SEP_DESC" />
+			<field name="separator_phone1_phone2" type="text" default="" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_AREA_PART2_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_AREA_PART2_SEP_DESC" />
+			<field name="separator_phone2_phone3" type="text" default="" size="3" label="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_PART2_PART3_SEP" description="PLG_FLEXICONTENT_FIELDS_PHONENUMBERS_PART2_PART3_SEP_DESC" />
 
 			<field name="" type="separator" default="FLEXI_FIELD_VALUE_LIST" description="" icon_class="icon-stack" level="tab_open" box_type="1" />
 			


### PR DESCRIPTION
This PR addresses the following issues regarding rendering of phone number separators:

1) It is not possible to completely remove a separator string. If the separator values are changed to blank, the system changes them to the default value. In order to fix this issue we have changed the default values to blank.

2) It is not possible to render a prefix before the area code (phone 1) when no country code is displayed. In order to fix this issue we are changing the logic that controls how the separators are displayed, as follows:

- The country code / phone 1 separator will be displayed when either the country code or the phone 1 are displayed

- The phone 1 / phone 2 separator will be always displayed.
