### PR TITLE
Update fcbase.php

### DIFF
--- a/admin/helpers/html/fcbase.php
+++ b/admin/helpers/html/fcbase.php
@@ -112,7 +112,7 @@ abstract class JHtmlFcbase
 
 		if (!$row->checked_out)
 		{
-			return '<span class="icon-pencil-2"></span>';
+			return '<span class="icon-pencil"></span>';
 		}
 
 		if (!$row->canCheckin)


### PR DESCRIPTION
fcbase is using this icon:

![](https://i.imgur.com/xVvJukW.png)

Should it be this icon to match Joomla?

![](https://i.imgur.com/9PkDMMG.png)

Also - in items view icon-pencil-2 is used to represent draft and edit items:

![](https://i.imgur.com/Rd4IHRs.png)