### PR TITLE
Allow loading additional template XML files

### DIFF
--- a/site/classes/helpers/tmpl.php
+++ b/site/classes/helpers/tmpl.php
@@ -72,7 +72,7 @@ class flexicontent_tmpl
 			if ( JFile::exists($tmplxml) && empty($themes->$layout_type->$tmplname) )
 			{
 				// Parse the XML file
-				$doc = @simplexml_load_file($tmplxml);
+				$doc = @simplexml_load_file($tmplxml, null, LIBXML_NOENT);
 				if (!$doc)
 				{
 					if (JFactory::getApplication()->isClient('administrator')) JFactory::getApplication()->enqueueMessage('Syntax error(s) in template XML file: '. $tmplxml, 'notice');


### PR DESCRIPTION
As discussed in https://github.com/FLEXIcontent/flexicontent-cck/issues/697

With this change, we allow for template XML files (category.xml and item.xml) to reference and embed additional XML files.

This is a useful way of extending existing templates with custom fields.

To use this feature you need the following:

1. On the template xml you want to extend you need to add the following code:

After `<?xml version="1.0" encoding="utf-8"?>` add the following:

```
<!DOCTYPE install PUBLIC "-//Joomla! 2.5//DTD template 1.0//EN" "http://www.joomla.org/xml/dtd/1.6/template-install.dtd" [
	<!ENTITY extend SYSTEM "extend.xml">
]>
```

and then place `&extend;` where you want to add the custom fields (for example, right before the closing `</fieldset>` tag).

2. You must create a file `extend.xml` in the same folder as the xml you are extending. This file doesn't need all the structure of category.xml or item.xml, only the fields you want to add, for example:

```
<?xml version="1.0" encoding="utf-8"?>
<field name="extend_sep" type="separator" hr="false" default="Extra Parameters" description="Extra Parameters" level="level1" menu="hide" />
<field name="extend_field_1_img" type="text" default="" label="extend_field_1_label" description="extend_field_1_desc" />
<field name="extend_field_2_img" type="textarea" default="" label="extend_field_2_label" description="extend_field_2_desc" />
<field name="extend_field_3_img" type="media" field_type="image" default="" label="extend_field_3_label" description="extend_field_3_desc" />
```
