### PR TITLE
Update prepare_value_display.php

### DIFF
--- a/plugins/flexicontent_fields/image/tmpl_common/prepare_value_display.php
+++ b/plugins/flexicontent_fields/image/tmpl_common/prepare_value_display.php
@@ -66,6 +66,10 @@
 	$alt_encoded   = htmlspecialchars($alt, ENT_COMPAT, 'UTF-8');
 	$desc_encoded  = htmlspecialchars($desc, ENT_COMPAT, 'UTF-8');
 
+  	//Declare incase not using srcset
+  	$w = '';
+ 	$h = '';
+
 	if (!$isURL)
 	{
 		$srcb = $thumb_urlpath . '/b_' .$extra_prefix. $image_name;  // backend


### PR DESCRIPTION
If we choose to not use srcset - then I am getting a php notice in universal content module:

![Image of Issue](https://i.imgur.com/D0eUrcx.png)

Notice: Undefined variable: w in D:\laragon\www\iam\plugins\flexicontent_fields\image\tmpl_common\prepare_value_display.php on line 281

Notice: Undefined variable: h in D:\laragon\www\iam\plugins\flexicontent_fields\image\tmpl_common\prepare_value_display.php on line 281