### PR TITLE
Issues with new custom functionality - Show/Hide fields depending on value of other fields, and nested field groups

### DIFF
--- a/admin/controllers/flexicontent.raw.php
+++ b/admin/controllers/flexicontent.raw.php
@@ -87,9 +87,7 @@ class FlexicontentControllerFlexicontent extends FlexicontentControllerBaseAdmin
 		$query = $db->getQuery(true)
             ->insert('#__flexicontent_fields')
             ->columns('
-                `id`, `field_type`, `name`, `label`, `description`, `isfilter`, `iscore`, `issearch`, `isadvsearch`,
-                `untranslatable`, `formhidden`, `valueseditable`, `edithelp`, `positions`, `published`, `attribs`,
-                `checked_out`, `checked_out_time`, `access`, `ordering`
+						(`id`,`field_type`,`name`,`label`,`description`,`isfilter`,`iscore`,`issearch`,`isadvsearch`,`untranslatable`,`formhidden`,`defaultviewbehavior`,`fieldviewbehavior`,`valueseditable`,`edithelp`,`positions`,`published`,`attribs`,`checked_out`,`checked_out_time`,`access`,`ordering`)
             ');
 
 		$values = array();
@@ -202,7 +200,7 @@ class FlexicontentControllerFlexicontent extends FlexicontentControllerBaseAdmin
 
 		JFactory::getLanguage()->load('plg_flexicontent_fields_coreprops', JPATH_ADMINISTRATOR, 'en-GB', true);
 		JFactory::getLanguage()->load('plg_flexicontent_fields_coreprops', JPATH_ADMINISTRATOR, null, true);
-		
+
 		// !! IMPORTANT core fields have specific fields ID, ranging from 1 - 14
 		// !! Make sure these have been creating before trying to add any other fields into the flexicontent_fields DB table
 		$this->createDefaultFields($_skip_success_msg = true);

--- a/admin/models/field.php
+++ b/admin/models/field.php
@@ -172,6 +172,10 @@ class FlexicontentModelField extends FCModelAdmin
 		$record->isadvsearch		= 0;
 		$record->untranslatable	= 0;
 		$record->formhidden			= 0;
+		$record->defaultviewbehavior			= 1;
+		$record->fieldviewbehavior		= 1;
+		$record->checkfieldname			= null;
+		$record->checkfieldvalue		= null;
 		$record->valueseditable	= 0;
 		$record->edithelp				= 2;
 		$record->positions			= array();

--- a/admin/models/forms/field.xml
+++ b/admin/models/forms/field.xml
@@ -24,7 +24,7 @@
 		<option value="0">FLEXI_NO</option>
 		<option value="1">FLEXI_YES</option>
 	</field>
-	
+
 	<field name="untranslatable" type="fcradio" default="0" label="FLEXI_FIELD_NON_TRANSLATABLE" description="FLEXI_FIELD_NON_TRANSLATABLE_DESC" class="btn-group btn-group-yesno" labelclass="fc-prop-lbl">
 		<option value="0">FLEXI_NO</option>
 		<option value="1">FLEXI_YES</option>
@@ -36,6 +36,16 @@
 		<option value="3">FLEXI_BOTH</option>
 		<option value="4">FLEXI_IF_EMPTY</option>
 	</field>
+	<field name="defaultviewbehavior" type="fcradio" default="1" label="Default Show/Hide Behavior" description="" class="btn-group btn-group-yesno" labelclass="fc-prop-lbl">
+		<option value="0">FLEXI_HIDE</option>
+		<option value="1">FLEXI_SHOW</option>
+	</field>
+	<field name="fieldviewbehavior" type="fcradio" default="1" label="Field Show/Hide Behavior" description="" class="btn-group btn-group-yesno" labelclass="fc-prop-lbl">
+		<option value="0">FLEXI_HIDE</option>
+		<option value="1">FLEXI_SHOW</option>
+	</field>
+	<field name="checkfieldname" type="text" default="" label="Show field if " description="Please enter the name of the field whose value you want checked to determine if this field is hidden or if it shows" labelclass="fc-prop-lbl" />
+	<field name="checkfieldvalue" type="text" default="" label=" has a value of " description="Please enter the value that will be checked for" labelclass="fc-prop-lbl" />
 	<field name="valueseditable" type="list" default="0" label="FLEXI_VALUES_EDITABLE_BY_ACL" description="FLEXI_VALUES_EDITABLE_BY_ACL_DESC" class="" labelclass="fc-prop-lbl">
 		<option value="0">FLEXI_ANY_EDITOR</option>
 		<option value="1">FLEXI_USE_ACL_AND_NO_EDIT_MSG</option>

--- a/admin/models/parentclassitem.php
+++ b/admin/models/parentclassitem.php
@@ -2796,7 +2796,7 @@ class ParentClassItem extends FCModelAdmin
 		$user    = JFactory::getUser();
 		$isSite  = $app->isClient('site');
 		$isAdmin = !$isSite;  // Treat non-site (e.g. CLI) as if being admin
-		
+
 		$dispatcher = JEventDispatcher::getInstance();
 		$cparams    = $this->_cparams;
 		$use_versioning = $cparams->get('use_versioning', 1);
@@ -3260,6 +3260,11 @@ class ParentClassItem extends FCModelAdmin
 					$obj->version			= (int)$last_version+1;
 					$use_ingroup = $field->parameters->get('use_ingroup', 0);
 
+					if ($field->nested == true) {
+						$indeces = $item->fields[$field->name]->parentindeces;
+						$obj->valueorder = $indeces[0];
+						$obj->suborder = $i;
+					}
 					// Serialize the properties of the value, normally this is redudant, since the field must have had serialized the parameters of each value already
 					if ( !empty($field->use_suborder) && is_array($posted_value) )
 						$obj->value = null;
@@ -3844,7 +3849,7 @@ class ParentClassItem extends FCModelAdmin
 
 		// b. Merge parameters from current category, but prevent some settings from propagating ... to the item, that are meant for
 		//    category view only, these are legacy settings that were removed from category.xml, but may exist in saved configurations
-		
+
 		// Do not merge ALL category parameters !! into item, as they are 99% irrelevant
 		if (0)
 		{

--- a/admin/tables/flexicontent_fields.php
+++ b/admin/tables/flexicontent_fields.php
@@ -99,6 +99,18 @@ class flexicontent_fields extends _flexicontent_fields
 	var $formhidden			= 0;
 
 	/** @var int */
+	var $defaultviewbehavior			= 1;
+
+	/** @var int */
+	var $fieldviewbehavior			= 1;
+
+	/** @var string */
+	var $checkfieldname				= null;
+
+	/** @var string */
+	var $checkfieldvalue	= '';
+
+	/** @var int */
 	var $valueseditable	= 0;
 
 	/** @var int */
@@ -175,7 +187,7 @@ class flexicontent_fields extends _flexicontent_fields
 		// Do not change alias of core fields that, keep the one provided by the model / caller
 		$config = (object) array('automatic_alias' => !$this->iscore);
 
-		// Check common properties, like title and alias 
+		// Check common properties, like title and alias
 		if (parent::_check_record($config) === false)
 		{
 			return false;

--- a/admin/views/field/tmpl/default.php
+++ b/admin/views/field/tmpl/default.php
@@ -5,7 +5,7 @@
  * @subpackage FLEXIcontent
  * @copyright (C) 2009 Emmanuel Danan - www.vistamedia.fr
  * @license GNU/GPL v2
- * 
+ *
  * FLEXIcontent is a derivative work of the excellent QuickFAQ component
  * @copyright (C) 2008 Christoph Lukes
  * see www.schlu.net for more information
@@ -43,7 +43,7 @@ $js = "
 /*$js .= "
 	jQuery( document ).ready(function() {".
 		($form->getValue("id") > 0 && $form->getValue("id") < 7 ? "
-		setTimeout(function(){ 
+		setTimeout(function(){
 			jQuery('#jform_published').css('pointer-events', 'none').off('click');
 			jQuery('#jform_published').find('.btn').addClass('disabled');
 			jQuery('#jform_name').attr('readonly', 'readonly');
@@ -61,9 +61,9 @@ $this->document->addScriptDeclaration($js);
 <div class="container-fluid row" style="padding: 0px !important; margin: 0px !important">
 
 	<div class="span6 col-6 full_width_980">
-	
+
 		<!--span class="badge"><h3><?php echo JText::_( /*'FLEXI_STANDARD_FIELDS_PROPERTIES'*/'Common configuration' ); ?></h3></span-->
-		
+
 		<table class="fc-form-tbl fcinner" style="margin-bottom:12px;">
 			<tr>
 				<td class="key">
@@ -95,7 +95,7 @@ $this->document->addScriptDeclaration($js);
 					{
 						$customize_mssg = flexicontent_html::getToolTip(JText::_('FLEXI_NOTES'), JText::sprintf('FLEXI_CORE_FIELDS_CUSTOMIZATION', 'text', '<b>'.JText::_('FLEXI_DESCRIPTION').'</b>', 'text'), 0, 1);
 					}
-					elseif ($form->getValue('field_type')=='maintext') 
+					elseif ($form->getValue('field_type')=='maintext')
 					{
 						$customize_mssg = flexicontent_html::getToolTip(JText::_('FLEXI_NOTES'), JText::sprintf('FLEXI_FIELD_CUSTOMIZE_PER_CONTENT_TYPE', 'textarea', 'text', 'text'), 0, 1);
 					}
@@ -112,7 +112,7 @@ $this->document->addScriptDeclaration($js);
 				</td>
 			</tr>
 
-			
+
 			<?php if ($form->getValue("iscore") == 0) : ?>
 			<tr>
 				<td class="key">
@@ -127,12 +127,12 @@ $this->document->addScriptDeclaration($js);
 			<?php endif; ?>
 
 		</table>
-		
+
 		<div class="fctabber fields_tabset" id="field_basic_props_tabset">
-			
+
 			<div class="tabbertab" id="fcform_tabset_common_basic_tab" data-icon-class="icon-home-2" >
 				<h3 class="tabberheading hasTooltip"> <?php echo JText::_( 'FLEXI_BASIC' ); ?> </h3>
-				
+
 				<table class="fc-form-tbl fcinner">
 					<tr>
 						<td class="key">
@@ -142,7 +142,7 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('published'); ?>
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td class="key">
 							<?php echo $form->getLabel('access'); ?>
@@ -151,7 +151,7 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('access'); ?>
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td class="key">
 							<?php echo $form->getLabel('ordering'); ?>
@@ -161,8 +161,8 @@ $this->document->addScriptDeclaration($js);
 						</td>
 					</tr>
 				</table>
-				
-				<div class="fcclear"></div>				
+
+				<div class="fcclear"></div>
 
 				<table class="fc-form-tbl fcinner">
 					<tr>
@@ -182,14 +182,14 @@ $this->document->addScriptDeclaration($js);
 						</td>
 					</tr>
 				</table>
-					
+
 			</div>
-			
-			
+
+
 			<div class="tabbertab" id="fcform_tabset_common_item_form_tab" data-icon-class="icon-pencil" >
 				<h3 class="tabberheading"> <?php echo JText::_( 'FLEXI_ITEM_FORM' ); ?> </h3>
 				<table class="fc-form-tbl fcinner">
-					
+
 					<tr<?php echo !$this->supportuntranslatable?' style="display:none;"':'';?>>
 						<td class="key">
 							<?php echo $form->getLabel('untranslatable'); ?>
@@ -198,7 +198,7 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('untranslatable'); ?>
 						</td>
 					</tr>
-	
+
 					<tr<?php echo !$this->supportformhidden?' style="display:none;"':'';?>>
 						<td class="key">
 							<?php echo $form->getLabel('formhidden'); ?>
@@ -207,7 +207,27 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('formhidden'); ?>
 						</td>
 					</tr>
-					
+					<tr>
+						<td class="key">
+							<?php echo $form->getLabel('defaultviewbehavior'); ?>
+						</td>
+						<td>
+							<?php echo $form->getInput('defaultviewbehavior'); ?>
+						</td>
+					</tr>
+					<tr>
+						<td class="key">
+							<?php echo $form->getLabel('fieldviewbehavior'); ?>
+						</td>
+						<td>
+							<?php echo $form->getInput('fieldviewbehavior'); ?>
+						</td>
+					</tr>
+					<tr>
+						<td>
+						<?php echo $form->getLabel('checkfieldname'); ?><?php echo $form->getInput('checkfieldname'); ?><?php echo $form->getLabel('checkfieldvalue'); ?><?php echo $form->getInput('checkfieldvalue'); ?>
+						</td>
+					</tr>
 					<tr<?php echo !$this->supportvalueseditable?' style="display:none;"':'';?>>
 						<td class="key">
 							<?php echo $form->getLabel('valueseditable'); ?>
@@ -216,7 +236,7 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('valueseditable'); ?>
 						</td>
 					</tr>
-					
+
 					<tr<?php echo !$this->supportedithelp?' style="display:none;"':'';?>>
 						<td class="key">
 							<?php echo $form->getLabel('edithelp'); ?>
@@ -225,7 +245,7 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('edithelp'); ?>
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td class="key">
 							<?php echo $form->getLabel('description'); ?>
@@ -234,20 +254,20 @@ $this->document->addScriptDeclaration($js);
 							<?php echo $form->getInput('description'); ?>
 						</td>
 					</tr>
-					
+
 				</table>
 			</div>
-			
-			
+
+
 			<?php if ($this->supportsearch || $this->supportfilter || $this->supportadvsearch || $this->supportadvfilter) : ?>
 			<div class="tabbertab" id="fcform_tabset_common_search_filtering_tab" data-icon-class="icon-search" >
 				<h3 class="tabberheading"> <?php echo JText::_( 'FLEXI_FIELD_SEARCH_FILTERING' ); ?> </h3>
-				
+
 				<?php if ($this->supportsearch || $this->supportfilter) : ?>
 					<span class="fcsep_level1" style="width:90%; margin-top:16px;"><?php echo JText::_( 'FLEXI_BASIC_INDEX' ); ?></span>
 					<span class="fcsep_level4 alert alert-info" style="margin-left: 32px;"><?php echo JText::_( 'FLEXI_BASIC_INDEX_NOTES' ); ?></span>
 					<div class="fcclear"></div>
-				
+
 					<table class="fc-form-tbl fcinner">
 						<?php if ($this->supportsearch) : ?>
 						<tr>
@@ -257,7 +277,7 @@ $this->document->addScriptDeclaration($js);
 							<td>
 								<?php echo
 									in_array($form->getValue('issearch'),array(-1,2)) ?
-										JText::_($form->getValue('issearch')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' -- 
+										JText::_($form->getValue('issearch')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' --
 										<a href="index.php?option=com_flexicontent&view=search&layout=indexer&tmpl=component&indexer=basic" class="btn btn-warning" onclick="var url = jQuery(this).attr(\'href\'); fc_showDialog(url, \'fc_modal_popup_container\', 0, 550, 350, function(){window.location.reload(false)}); return false;">'
 											.JText::_('FLEXI_FIELD_DIRTY_REBUILD_SEARCH_INDEX').'
 										</a>' :
@@ -265,7 +285,7 @@ $this->document->addScriptDeclaration($js);
 							</td>
 						</tr>
 						<?php endif; ?>
-						
+
 						<?php if ($this->supportfilter) : ?>
 						<tr>
 							<td class="key">
@@ -274,7 +294,7 @@ $this->document->addScriptDeclaration($js);
 							<td>
 								<?php echo
 									in_array($form->getValue('isfilter'),array(-1,2)) ?
-										JText::_($form->getValue('isfilter')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' -- 
+										JText::_($form->getValue('isfilter')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' --
 										<a href="index.php?option=com_flexicontent&view=search&layout=indexer&tmpl=component&indexer=basic" class="btn btn-warning" onclick="var url = jQuery(this).attr(\'href\'); fc_showDialog(url, \'fc_modal_popup_container\', 0, 550, 350, function(){window.location.reload(false)}); return false;">'
 											.JText::_('FLEXI_FIELD_DIRTY_REBUILD_SEARCH_INDEX').'
 										</a>' :
@@ -284,13 +304,13 @@ $this->document->addScriptDeclaration($js);
 						<?php endif; ?>
 					</table>
 				<?php endif; ?>
-				
-				
+
+
 				<?php if ($this->supportadvsearch || $this->supportadvfilter) : ?>
 					<span class="fcsep_level1" style="width:90%; margin-top:16px; "><?php echo JText::_( 'FLEXI_ADV_INDEX' ); ?></span>
 					<span class="fcsep_level4 alert alert-info" style="margin-left: 32px;"><?php echo JText::_( 'FLEXI_ADV_INDEX_NOTES' ); ?></span>
 					<div class="fcclear"></div>
-					
+
 					<table class="fc-form-tbl fcinner">
 						<?php if ($this->supportadvsearch) : ?>
 						<tr>
@@ -300,7 +320,7 @@ $this->document->addScriptDeclaration($js);
 							<td>
 								<?php echo
 									in_array($form->getValue('isadvsearch'),array(-1,2)) ?
-										JText::_($form->getValue('isadvsearch')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' -- 
+										JText::_($form->getValue('isadvsearch')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' --
 										<a href="index.php?option=com_flexicontent&view=search&layout=indexer&tmpl=component&indexer=advanced" class="btn btn-warning" onclick="var url = jQuery(this).attr(\'href\'); fc_showDialog(url, \'fc_modal_popup_container\', 0, 550, 350, function(){window.location.reload(false)}); return false;">'
 											.JText::_('FLEXI_FIELD_DIRTY_REBUILD_SEARCH_INDEX').'
 										</a>' :
@@ -308,7 +328,7 @@ $this->document->addScriptDeclaration($js);
 							</td>
 						</tr>
 						<?php endif; ?>
-						
+
 						<?php if ($this->supportadvfilter) : ?>
 						<tr>
 							<td class="key">
@@ -317,7 +337,7 @@ $this->document->addScriptDeclaration($js);
 							<td>
 								<?php echo
 									in_array($form->getValue('isadvfilter'),array(-1,2)) ?
-										JText::_($form->getValue('isadvfilter')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' -- 
+										JText::_($form->getValue('isadvfilter')==-1 ? 'FLEXI_NO' : 'FLEXI_YES') .' --
 										<a href="index.php?option=com_flexicontent&view=search&layout=indexer&tmpl=component&indexer=advanced" class="btn btn-warning" onclick="var url = jQuery(this).attr(\'href\'); fc_showDialog(url, \'fc_modal_popup_container\', 0, 550, 350, function(){window.location.reload(false)}); return false;">'
 											.JText::_('FLEXI_FIELD_DIRTY_REBUILD_SEARCH_INDEX').'
 										</a>' :
@@ -327,14 +347,14 @@ $this->document->addScriptDeclaration($js);
 						<?php endif; ?>
 					</table>
 				<?php endif; ?>
-				
+
 			</div>
 			<?php endif; ?>
 
 			<?php if ($this->perms->CanConfig) : ?>
 			<div class="tabbertab" id="fcform_tabset_common_perms_tab" data-icon-class="icon-power-cord" >
 				<h3 class="tabberheading"> <?php echo JText::_( 'FLEXI_PERMISSIONS' ); ?> </h3>
-				
+
 				<?php /*
 				<fieldset id="flexiaccess" class="flexiaccess basicfields_set">
 					<legend><?php echo JText::_( 'FLEXI_RIGHTS_MANAGEMENT' ); ?></legend>
@@ -348,17 +368,17 @@ $this->document->addScriptDeclaration($js);
 					</div>
 				</fieldset>
 				*/ ?>
-				
+
 			</div>
-			<?php endif; ?>		
-			
+			<?php endif; ?>
+
 		</div>
 
 	</div>
 	<div class="span6 col-6 full_width_980 padded_wrap_box">
-			
+
 		<span class="fcsep_level0" style="margin:0 0 12px 0; background-color:#777; "><?php echo JText::_( /*'FLEXI_THIS_FIELDTYPE_PROPERTIES'*/'FIELD TYPE specific configuration' ); ?></span>
-			
+
 		<div id="fieldspecificproperties">
 			<div class="fctabber fields_tabset" id="field_specific_props_tabset">
 			<?php
@@ -377,11 +397,11 @@ $this->document->addScriptDeclaration($js);
 				if ($name!='basic' && $name!='standard' && (substr($name, 0, $prefix_len)!='group-'.$field_type.'-' || $name==='group-'.$field_type) ) continue;
 				if ($fieldSet->label) $label = JText::_($fieldSet->label);
 				else $label = $name=='basic' || $name=='standard' ? JText::_('FLEXI_BASIC') : ucfirst(str_replace("group-", "", $name));
-				
+
 				if (@$fieldSet->label_prefix) $label = JText::_($fieldSet->label_prefix) .' - '. $label;
 				$icon = @$fieldSet->icon_class ? 'data-icon-class="'.$fieldSet->icon_class.'"' : '';
 				$prepend = @$fieldSet->prepend_text ? 'data-prefix-text="'.JText::_($fieldSet->prepend_text).'"' : '';
-				
+
 				$description = $fieldSet->description ? JText::_($fieldSet->description) : '';
 				?>
 				<div class="tabbertab" id="fcform_tabset_<?php echo $name; ?>_tab" <?php echo $icon; ?> <?php echo $prepend; ?>>

--- a/plugins/flexicontent_fields/fieldgroup/fieldgroup.php
+++ b/plugins/flexicontent_fields/fieldgroup/fieldgroup.php
@@ -90,7 +90,7 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 		 */
 
 		// Get fields belonging to this field group
-		$grouped_fields = $this->getGroupFields($field);
+		$grouped_fields = $this->getGroupFields($field, $item);
 
 		// Get values of fields making sure that also empty values are created too
 		$max_count = 1;
@@ -233,7 +233,7 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 			$js .= "
 				lastField ?
 					(insert_before ? newField.insertBefore( lastField ) : newField.insertAfter( lastField ) ) :
-					newField.appendTo( jQuery('#sortables_".$field->id."') ) ;
+					newField.appendTo( el.closest(jQuery('#sortables_".$field->id."')) ) ;
 				";
 
 			// Add new element to sortable objects (if field not in group) -- NOTE: remove_previous: 2 means remove element without do any cleanup actions
@@ -344,17 +344,51 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 		{
 			$compact_edit_excluded = $field->parameters->get('compact_edit_excluded', array());
 
-			if (empty($compact_edit_excluded))
-			{
-				$compact_edit_excluded = array();
-			}
-			if (!is_array($compact_edit_excluded))
-			{
-				$compact_edit_excluded = preg_split("/[\|,]/", $compact_edit_excluded);
-			}
 
-			$compact_edit_excluded = array_flip($compact_edit_excluded);
-		}
+		$field->html = array();
+		for ($n = 0; $n < $max_count; $n++)
+		{
+			$field->html[$n] = '
+				'.(!$add_ctrl_btns ? '' : '
+				<div class="'.$input_grp_class.' fc-xpended-btns">
+					'.$move2.'
+					'.$remove_button.'
+					'.$togglers.'
+					'.(!$add_position ? '' : $add_here).'
+				</div>
+				');
+
+			// Append item-form display HTML of the every field in the group
+			$i = 0;
+			foreach($grouped_fields as $field_id => $grouped_field)
+			{
+				$hide_field = '';
+				if ($grouped_field->defaultviewbehavior == 0) {
+					if ($grouped_field->defaultviewbehavior !== $grouped_field->fieldviewbehavior) {
+						$target_field = $grouped_field->checkfieldname;
+						$target_field_id = $item->fields[$target_field]->id;
+						$target_field_value = $grouped_field->checkfieldvalue;
+						if ($grouped_fields[$target_field_id]->value[$n] !== $target_field_value) {
+							$hide_field = ' style="display:none;"';
+						}
+					}
+				}
+				if ($grouped_field->formhidden == 4) continue;
+				if ($isAdmin) {
+					if ( $grouped_field->parameters->get('backend_hidden')  ||  (isset($grouped_field->formhidden_grp) && in_array($grouped_field->formhidden_grp, array(2,3))) ) continue;
+				} else {
+					if ( $grouped_field->parameters->get('frontend_hidden') ||  (isset($grouped_field->formhidden_grp) && in_array($grouped_field->formhidden_grp, array(1,3))) ) continue;
+				}
+
+				// Check for not-assigned to type fields,
+				if (!isset($grouped_field->html[$n]))
+				{
+					if ($form_empty_fields)
+					{
+						$grouped_field->html[$n] = '<i>' . $form_empty_fields_text . '</i>';
+					}
+					else continue;
+				}
 
 
 		/**
@@ -366,8 +400,21 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 		$formlayout = $field->parameters->get('formlayout', '');
 		$formlayout = $formlayout ? 'field_'.$formlayout : 'field_list';
 
-		include(self::getFormPath($this->fieldtypes[0], $formlayout));
+				$field->html[$n] .= '<div class="fcclear"></div>
+				<div class="fcfieldval_container_outer'.($compact_edit && isset($compact_edit_excluded[$field_id]) ? ' fcAlwaysVisibleField' : '').'"'.($hide_field !== '' ? $hide_field : '').'>
+					<label id="custom_'.$grouped_field->name.'_'.$n.'-lbl" class="'.$lbl_class.'" title="'.$lbl_title.'" data-for="custom_'.$grouped_field->name.'_'.$n.'">'.$grouped_field->label.'</label>
+					<div class="fcfieldval_container valuebox fcfieldval_container_'.$grouped_field->id.'" >
+						' . ($grouped_field->description && $edithelp==3 ? sprintf( $alert_box, '', 'info', 'fc-nobgimage', $grouped_field->description ) : '') . '
+						' . ($grouped_field->field_type == 'fieldgroup' ? $grouped_field->html : $grouped_field->html[$n]) . '
+					</div>
+				</div>
+					';
+				$i++;
+			}
+		}
 
+		if (!$multiple) break;  // multiple values disabled, break out of the loop, not adding further values even if the exist
+	}
 
 		/**
 		 * Non value HTML
@@ -435,7 +482,6 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 				' : '').'
 			' . $field->html;
 	}
-
 
 	// Method to create field's HTML display for frontend views
 	public function onDisplayFieldValue(&$field, $item, $values = null, $prop = 'display')
@@ -512,7 +558,7 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 
 
 		// Get fields belonging to this field group
-		$grouped_fields = $this->getGroupFields($field);
+		$grouped_fields = $this->getGroupFields($field, $item);
 
 		// Get values of fields making sure that also empty values are created too
 		$max_count = 0;
@@ -754,9 +800,12 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 				//echo 'Replacing: '. $_rendered_field->name . ', method: ' . $method . ', index: ' .$n. '<br/>';
 				if ($method !== 'label' && $method !== 'id' && $method !== 'name')
 				{
-					$_html = isset($_rendered_field->{$method.'_arr'}[$n]) ? $_rendered_field->{$method.'_arr'}[$n] : '';
+					if ($_rendered_field->field_type == 'fieldgroup') {
+						$_html = isset($_rendered_field->{$method.'_arr'}[$n]) ? $_rendered_field->{$method.'_arr'} : '';
+					} else {
+						$_html = isset($_rendered_field->{$method.'_arr'}[$n]) ? $_rendered_field->{$method.'_arr'}[$n] : '';
+					}
 				}
-
 				// Skip (hide) label for field having none display HTML (is such behaviour was configured)
 				elseif ($method === 'label')
 				{
@@ -795,6 +844,34 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 	// Method to handle field's values before they are saved into the DB
 	public function onBeforeSaveField( &$field, &$post, &$file, &$item )
 	{
+		//before we save this, due to the presence of nested fields, we need to change the valueorder and suborder of nested fields within a nested groupfield
+		//first things first, we parse whether or not this is used in a group, if not, skip all else.
+		$attribs = str_replace('"', '', explode(',', $field->attribs));
+		$group = explode(':', $attribs[0])[1];
+		//if the field is within another group, we need to check the fields, get the index of the parent item they're under, and go from there
+		if ($group == 1) {
+			//this is a heavy-handed way to get this, if it can be simplified later that would be ideal
+			$grouped_fields = $this->getGroupFields($field, $item);
+			//we can't use "field" here as that is used for the main parent field
+			foreach($grouped_fields as $raw_field) {
+				$raw_field->nested = true;
+				$raw_field->parent_field_id = $field->id;
+				$raw_field->parent_field_name = $field->name;
+				$raw_field->dependent_field = $field-> checkfieldname;
+				$dependent_field_id = $item->fields[$raw_field->dependent_field]->id;
+				$dependent_field_check = $field-> checkfieldvalue;
+				$dependent_field_values = $item->fieldvalues[$dependent_field_id];
+				if (!isset($raw_field->parentindeces)) $raw_field->parentindeces = [];
+				$i = 1;
+				foreach($dependent_field_values as $value) {
+					if ($value == $dependent_field_check) {
+						array_push($raw_field->parentindeces, $i);
+					}
+					$i++;
+				}
+				$item->fields[$raw_field->name] = $raw_field;
+			}
+		}
 		if ( !in_array($field->field_type, static::$field_types) ) return;
 	}
 
@@ -819,7 +896,7 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 	// ***
 
 	// Retrieves the fields that are part of the given 'fieldgroup' field
-	function getGroupFields(&$field)
+	function getGroupFields(&$field, &$item)
 	{
 		static $grouped_fields = array();
 		if (isset($grouped_fields[$field->id])) return $grouped_fields[$field->id];
@@ -845,19 +922,59 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 			;
 		$db->setQuery($query);
 		$grouped_fields[$field->id] = $db->loadObjectList('id');
-
 		$_grouped_fields = array();
-		foreach($grouped_fields[$field->id] as $field_id => $grouped_field)
-		{
-			// Create field parameters, if not already created, NOTE: for 'custom' fields loadFieldConfig() is optional
-			if (empty($grouped_field->parameters)) {
-				$grouped_field->parameters = new JRegistry($grouped_field->attribs);
-			}
 
-			// Check if field is not set to participate in a field group and skip it
-			if ( !$grouped_field->parameters->get('use_ingroup') ) continue;
-			$_grouped_fields[$field_id] = $grouped_field;
+		foreach($grouped_fields[$field->id] as $field_id => $grouped_field) {
+			if ($grouped_field->field_type == 'fieldgroup') {
+				$grouped_field->nested_fields = [];
+				// Create field parameters, if not already created, NOTE: for 'custom' fields loadFieldConfig() is optional
+				if (empty($grouped_field->parameters)) {
+					$grouped_field->parameters = new JRegistry($grouped_field->attribs);
+				}
+
+				$_fieldgroup_fields = $grouped_field->parameters->get('fields', array());
+
+				// break $_fieldgroup_fields into array at ,
+				if ( !is_array($_fieldgroup_fields) ) {
+					$_fieldgroup_fields = preg_split("/[\|,]/", $_fieldgroup_fields);
+				}
+				// loop through the fields of the fieldgroup and add them to the list of fields to be returned
+				foreach($_fieldgroup_fields as $fieldgroup_field) {
+					$db = JFactory::getDbo();
+					$query = 'SELECT f.*'
+						. ' FROM #__flexicontent_fields AS f'
+						. ' WHERE f.published = 1'
+						. ' AND f.id = '.$fieldgroup_field
+						;
+					$db->setQuery($query);
+					$field_data = $db->loadObject();
+					$field_data->values = [];
+					$query = 'SELECT ffir.* '
+						. ' FROM #__flexicontent_fields_item_relations AS ffir'
+						. ' WHERE ffir.item_id = '. $item->id .' AND ffir.field_id =' .$fieldgroup_field
+						. ' ORDER BY ffir.valueorder';
+						;
+					$db->setQuery($query);
+					$field_values = $db->loadObjectList();
+					$field_data->values = $field_values;
+					array_push($grouped_field->nested_fields, $field_data);
+				}
+				$_grouped_fields[$field_id] = $grouped_field;
+			} else {
+				// Create field parameters, if not already created, NOTE: for 'custom' fields loadFieldConfig() is optional
+				if (empty($grouped_field->parameters)) {
+					$grouped_field->parameters = new JRegistry($grouped_field->attribs);
+				}
+
+				// Check if field is not set to participate in a field group and skip it
+				// if ( !$grouped_field->parameters->get('use_ingroup') ) continue;
+				$_grouped_fields[$field_id] = $grouped_field;
+
+			}
 		}
+
+		// print_r($grouped_fields[$field->id]);
+
 		$grouped_fields[$field->id] = $_grouped_fields;
 
 		return $grouped_fields[$field->id];
@@ -867,6 +984,7 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 	// Retrieves and add values to the given field objects
 	function getGroupFieldsValues(&$field, &$item, &$grouped_fields, &$max_count)
 	{
+
 		$do_compact = true;
 
 		// ****************
@@ -876,6 +994,22 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 		foreach($grouped_fields as $field_id => $grouped_field)
 		{
 			// Item viewing
+			if (isset($grouped_field->nested_fields)) {
+				foreach($grouped_field->nested_fields as $nested_field) {
+					$nested_field_id = $nested_field->id;
+					if ( isset($item->fieldvalues[$nested_field_id]) ) {
+						$nested_field->value = is_array($item->fieldvalues[$nested_field_id])  ?  $item->fieldvalues[$nested_field_id]  :  array($item->fieldvalues[$nested_field_id]);
+					}
+					// Item form
+					else if ( isset($item->fields[$nested_field->name]->value) ) {
+						$nested_field->value = $item->fields[$nested_field->name]->value;
+					}
+					// Value not set
+					else {
+						$nested_field->value = null;
+					}
+				}
+			}
 			if ( isset($item->fieldvalues[$field_id]) ) {
 				$grouped_field->value = is_array($item->fieldvalues[$field_id])  ?  $item->fieldvalues[$field_id]  :  array($item->fieldvalues[$field_id]);
 			}
@@ -939,31 +1073,74 @@ class plgFlexicontent_fieldsFieldgroup extends FCField
 
 		if ($do_compact) foreach($grouped_fields as $field_id => $grouped_field)
 		{
-			$i = $start_at;
-			for ($n = $start_at; $n <= $max_index; $n++)
-			{
-				//echo $n." - ".$i."<br/>";
-				// Move down to fill empty gaps, if current index is not in sync, meaning 1 empty group was encountered -before-, and also if current (value) group is non-empty
-				if ( $n > $i && !isset($grp_isempty[$n]) )
-				{
-					$grouped_field->value[$i] = $grouped_field->value[$n];
-					if ( isset($grouped_field->value[$n]) )
+			if (isset($grouped_field->nested_fields)) {
+				foreach($grouped_field->nested_fields as $nested_field) {
+					$i = $start_at;
+					for ($n = $start_at; $n <= $max_index; $n++)
 					{
-						if ( isset($item->fieldvalues[$field_id]) )               $item->fieldvalues[$field_id][$i] = $grouped_field->value[$n];
-						if ( isset($item->fields[$grouped_field->name]->value) )  $item->fields[$grouped_field->name]->value[$i] = $grouped_field->value[$n];
+						//echo $n." - ".$i."<br/>";
+						// Move down to fill empty gaps, if current index is not in sync, meaning 1 empty group was encountered -before-, and also if current (value) group is non-empty
+						$nested_field->sorted_values = [];
+						foreach($nested_field->values as $value) {
+							$index = $value->valueorder;
+							$order = $value->suborder;
+
+							if (!isset($nested_field->sorted_values[$index])) $nested_field->sorted_values[$index] = [];
+							array_push($nested_field->sorted_values[$index], $value);
+
+						}
+						foreach($nested_field->sorted_values as $value_array) {
+							array_multisort($value_array);
+						}
+						if ( $n > $i && !isset($grp_isempty[$n]) )
+						{
+							$nested_field->value[$i] = $nested_field->value[$n];
+							if ( isset($nested_field->value[$n]) )
+							{
+								if ( isset($item->fieldvalues[$nested_field->id]) )               $item->fieldvalues[$nested_field->id][$i] = $nested_field->value[$n];
+								if ( isset($item->fields[$nested_field->name]->value) )  $item->fields[$nested_field->name]->value[$i] = $nested_field->value[$n];
+							}
+						}
+
+						// Unset moved groups or group with ALL-empty values
+						if ( $n > $i || isset($grp_isempty[$n]) )
+						{
+							unset($nested_field->value[$n]);
+							if ( isset($item->fieldvalues[$nested_field->id]) ) unset($item->fieldvalues[$nested_field->id][$n]);
+							if ( isset($item->fields[$nested_field->name]->value) ) unset($item->fields[$nested_field->name]->value[$n]);
+						}
+
+						// Increment adding position if group was not empty
+						if ( !isset($grp_isempty[$n]) ) $i++;
 					}
 				}
-
-				// Unset moved groups or group with ALL-empty values
-				if ( $n > $i || isset($grp_isempty[$n]) )
+			} else {
+				$i = $start_at;
+				for ($n = $start_at; $n <= $max_index; $n++)
 				{
-					unset($grouped_field->value[$n]);
-					if ( isset($item->fieldvalues[$field_id]) ) unset($item->fieldvalues[$field_id][$n]);
-					if ( isset($item->fields[$grouped_field->name]->value) ) unset($item->fields[$grouped_field->name]->value[$n]);
-				}
+					//echo $n." - ".$i."<br/>";
+					// Move down to fill empty gaps, if current index is not in sync, meaning 1 empty group was encountered -before-, and also if current (value) group is non-empty
+					if ( $n > $i && !isset($grp_isempty[$n]) )
+					{
+						$grouped_field->value[$i] = $grouped_field->value[$n];
+						if ( isset($grouped_field->value[$n]) )
+						{
+							if ( isset($item->fieldvalues[$field_id]) )               $item->fieldvalues[$field_id][$i] = $grouped_field->value[$n];
+							if ( isset($item->fields[$grouped_field->name]->value) )  $item->fields[$grouped_field->name]->value[$i] = $grouped_field->value[$n];
+						}
+					}
 
-				// Increment adding position if group was not empty
-				if ( !isset($grp_isempty[$n]) ) $i++;
+					// Unset moved groups or group with ALL-empty values
+					if ( $n > $i || isset($grp_isempty[$n]) )
+					{
+						unset($grouped_field->value[$n]);
+						if ( isset($item->fieldvalues[$field_id]) ) unset($item->fieldvalues[$field_id][$n]);
+						if ( isset($item->fields[$grouped_field->name]->value) ) unset($item->fields[$grouped_field->name]->value[$n]);
+					}
+
+					// Increment adding position if group was not empty
+					if ( !isset($grp_isempty[$n]) ) $i++;
+				}
 			}
 		}
 		//echo "<br/><br/><br/>COMPACTED<br/><pre>"; foreach($grouped_fields as $field_id => $grouped_field) { echo "\n[".$grouped_field->id."] - ".$grouped_field->name; print_r($grouped_field->value); } echo "</pre>";

--- a/plugins/flexicontent_fields/fieldgroup/fieldgroup.xml
+++ b/plugins/flexicontent_fields/fieldgroup/fieldgroup.xml
@@ -28,20 +28,26 @@
 
 			<field name="" type="separator" default="FLEXI_FIELD_VALUES" icon_class="icon-database" level="tab_open" box_type="1" />
 
-			<field name="" type="separator" default="FLEXI_FIELD_GROUPING" description="" depend_class="fieldgroupoff" level="level2" />
+			<field name="" type="separator" default="FLEXI_FIELD_GROUPING" description="" level="level2" />
+
+			<field name="use_ingroup" type="multilist" subtype="radio" toggle_related="1" default="0" label="FLEXI_USE_IN_FIELD_GROUP" description="FLEXI_USE_IN_FIELD_GROUP_DESC" inline_tip="FLEXI_USE_IN_FIELD_GROUP_INSTRUCTIONS" tip_class="fieldgroupon" tip_img="comments.png" preview_img="insert_merge_field.png" class="btn-group group-fcinfo">
+				<option value="0">FLEXI_NO</option>
+				<option value="1">FLEXI_YES</option>
+			</field>
+
 			<field name="fields" type="fields" multiple="false" groupables="1" issortable="1" default="" label="Fields" description="Select fields that will be show shown as a group" />
 
-			<field name="" type="separator" default="FLEXI_FIELD_NUMBER_OF_VALUES" description="" depend_class="fieldgroupoff" level="level2" />
+			<field name="" type="separator" default="FLEXI_FIELD_NUMBER_OF_VALUES" description="" level="level2" />
 			<field name="required" type="radio" default="0" label="FLEXI_FIELD_REQUIRED" description="FLEXI_FIELD_REQUIRED_DESC" class="btn-group btn-group-yesno">
 				<option value="0">FLEXI_NO</option>
 				<option value="1">FLEXI_YES</option>
 			</field>
-			<field name="allow_multiple" type="multilist" subtype="radio" toggle_related="1" default="0" label="FLEXI_FIELD_ALLOW_MULTIPLE" description="FLEXI_FIELD_ALLOW_MULTIPLE_DESC" depend_class="fieldgroupoff" tip_class="multivalue-mode" tip_img="warning.png" class="btn-group group-fcmethod fcnoyes">
+			<field name="allow_multiple" type="multilist" subtype="radio" toggle_related="1" default="0" label="FLEXI_FIELD_ALLOW_MULTIPLE" description="FLEXI_FIELD_ALLOW_MULTIPLE_DESC" tip_class="multivalue-mode" tip_img="warning.png" class="btn-group group-fcmethod fcnoyes">
 				<option value="0" show_list="" hide_list="multivalue-mode">FLEXI_NO</option>
 				<option value="1" show_list="multivalue-mode" hide_list="">FLEXI_YES</option>
 			</field>
-			<field name="max_values" type="text" default="0" size="2" label="FLEXI_FIELD_MAX_VALUES" description="FLEXI_FIELD_MAX_VALUES_DESC" depend_class="fieldgroupoff multivalue-mode" />
-			<field name="add_position" type="multilist" subtype="radio" default="3" label="FLEXI_FIELD_ADD_POSITION" description="FLEXI_FIELD_ADD_POSITION_DESC" depend_class="fieldgroupoff multivalue-mode" class="btn-group group-fcinfo">
+			<field name="max_values" type="text" default="0" size="2" label="FLEXI_FIELD_MAX_VALUES" description="FLEXI_FIELD_MAX_VALUES_DESC" depend_class="multivalue-mode" />
+			<field name="add_position" type="multilist" subtype="radio" default="3" label="FLEXI_FIELD_ADD_POSITION" description="FLEXI_FIELD_ADD_POSITION_DESC" depend_class="multivalue-mode" class="btn-group group-fcinfo">
 				<option value="0">FLEXI_FIELD_APPEND_BTN</option>
 				<option value="1">FLEXI_FIELD_INLINE_APPEND_BTN</option>
 				<option value="2">FLEXI_FIELD_INLINE_PREPEND_BTN</option>

--- a/plugins/flexicontent_fields/fieldgroup/tmpl/field_list.php
+++ b/plugins/flexicontent_fields/fieldgroup/tmpl/field_list.php
@@ -19,6 +19,17 @@ for ($n = 0; $n < $max_count; $n++)
 	$i = 0;
 	foreach($grouped_fields as $field_id => $grouped_field)
 	{
+		$hide_field = '';
+		if ($grouped_field->defaultviewbehavior == 0) {
+			if ($grouped_field->defaultviewbehavior !== $grouped_field->fieldviewbehavior) {
+				$target_field = $grouped_field->checkfieldname;
+				$target_field_id = $item->fields[$target_field]->id;
+				$target_field_value = $grouped_field->checkfieldvalue;
+				if ($grouped_fields[$target_field_id]->value[$n] !== $target_field_value) {
+					$hide_field = ' style="display:none;"';
+				}
+			}
+		}
 		if ($grouped_field->formhidden == 4) continue;
 		if ($isAdmin) {
 			if ( $grouped_field->parameters->get('backend_hidden')  ||  (isset($grouped_field->formhidden_grp) && in_array($grouped_field->formhidden_grp, array(2,3))) ) continue;
@@ -60,7 +71,7 @@ for ($n = 0; $n < $max_count; $n++)
 
 		$field->html[$n] .= (empty($isFlexBox) ? '' : '
 		<div class="fc_form_flex_box_item' . ($use_flex_grow ? ' use_flex_grow' : '') . '" style="margin: 0;">') . '
-			<div class="control-group control-fc_subgroup fcfieldval_container_outer' . $gf_compactedit . '">
+			<div class="control-group control-fc_subgroup fcfieldval_container_outer' . $gf_compactedit . '"'.($hide_field !== '' ? $hide_field : '').'>
 				<div
 					class="control-label ' . ($gf_display_label_form === 2 ? 'fclabel_cleared' : '') . '"
 					style="' . ($gf_display_label_form < 1 ? 'display:none;' : '') .'"

--- a/plugins/flexicontent_fields/fieldgroup/tmpl/value_default.php
+++ b/plugins/flexicontent_fields/fieldgroup/tmpl/value_default.php
@@ -20,12 +20,18 @@ for ($n = 0; $n < $max_count; $n++)
 		}
 
 		// Add field's HTML (optionally including label)
-		$default_html[] = '
-		<div class="fc-field-box field_' . $grouped_field->name . '">
-			'.($grouped_field->parameters->get('display_label') ? '
-			<span class="flexi label">'.$grouped_field->label.'</span>' : '').
-			(isset($grouped_field->{$method.'_arr'}[$n]) ? '<div class="flexi value">'.$grouped_field->{$method.'_arr'}[$n].'</div>' : '').'
-		</div>';
+		if ($grouped_field->field_type == 'fieldgroup') {
+			$default_html[] = '<div class="fc-field-box field_' . $grouped_field->name . '">'.
+			$item->fields[$_grouped_field->name]->display_arr.'
+			</div>';
+		} else {
+			$default_html[] = '
+			<div class="fc-field-box field_' . $grouped_field->name . '">
+				'.($grouped_field->parameters->get('display_label') ? '
+				<span class="flexi label">'.$grouped_field->label.'</span>' : '').
+				(isset($grouped_field->{$method.'_arr'}[$n]) ? '<div class="flexi value">'.$grouped_field->{$method.'_arr'}[$n].'</div>' : '').'
+			</div>';
+		}
 	}
 
 	if (count($default_html))

--- a/site/classes/flexicontent.fields.php
+++ b/site/classes/flexicontent.fields.php
@@ -533,6 +533,21 @@ class FlexicontentFields
 			$field->formhidden = 3;
 			return;
 		}
+			//check for new method of hiding and showing fields
+			if ($field->parameters->get('defaultviewbehavior')== 0) {
+				//if the field is inside a group, logic within the fieldgroup.php and the associated field_list.php file handles this, so skip it
+				if ($field->parameters->get('use_ingroup') !== "1") {
+					if ($field->defaultviewbehavior !== $field->fieldviewbehavior) {
+						$target_field = $field->checkfieldname;
+						$target_field_value = $field->checkfieldvalue;
+						if ($item->fields[$target_field]->value[0] !== $target_field_value) {
+							$field->formhidden = 3;
+							return;
+						}
+					}
+				}
+
+			}
 
 		$is_editable = !$field->valueseditable || $user->authorise('flexicontent.editfieldvalues', 'com_flexicontent.field.' . $field->id);
 		if ($is_editable)
@@ -2079,7 +2094,7 @@ class FlexicontentFields
 
 			/**
 			 * Load frontend language overrides of item's language
-			 * then overwrite with backend language overrides 
+			 * then overwrite with backend language overrides
 			 * we do this because ... anyway search index is backend only
 			 */
 			$lang_overrides[$iLang] = array();
@@ -2222,7 +2237,7 @@ class FlexicontentFields
 					$lang_string         = strtoupper($results[$val]->text);
 					$results[$val]->text = JText::_(isset($overrides[$lang_string]) ? $overrides[$lang_string] : $results[$val]->text);
 				}
-				
+
 				$el_prop_count = 2;
 				$_props = !empty($extra_props) ? $extra_props : $default_extra_props;
 
@@ -3197,7 +3212,7 @@ class FlexicontentFields
 			$query  = 'SELECT c.id AS value_id, rel.itemid AS itemid, '
 				. (FLEXI_FALANG
 					? 'CONCAT_WS(\' \',
-						CASE WHEN (fat.value IS NOT NULL) THEN fat.value ELSE c.title END, 
+						CASE WHEN (fat.value IS NOT NULL) THEN fat.value ELSE c.title END,
 						CASE WHEN (fak.value IS NOT NULL) THEN fak.value ELSE c.metakey END
 					)'
 					: 'CONCAT_WS(\' \', c.title, c.metakey)'
@@ -3219,7 +3234,7 @@ class FlexicontentFields
 			$query  = 'SELECT t.id AS value_id, rel.itemid AS itemid, '
 				. (FLEXI_FALANG
 					? 'CONCAT_WS(\' \',
-						CASE WHEN (fat.value IS NOT NULL) THEN fat.value ELSE t.name END, 
+						CASE WHEN (fat.value IS NOT NULL) THEN fat.value ELSE t.name END,
 						CASE WHEN (fak.value IS NOT NULL) THEN fak.value ELSE jt.metakey END
 					)'
 					: 'CONCAT_WS(\' \', t.name, jt.metakey)'


### PR DESCRIPTION
I've been working with Ruben Reyes at Lyquix for the past few years as well as Georgios and have contributed to Lyquix's flexicontent templates (https://github.com/Lyquix/flexicontent_templates), but this is the first attempt at contributing to core flexicontent functionality I've made. While working on some new functionality to use on a client’s site I ran into some issues that I’d like help with resolving.

For the last couple weeks I've been working to create a system of nested field groups as well as an ability to show or hide fields depending on the value of another field. The latter seems to be working well but I am having trouble with the former, namely with creating associations between fields within nested field groups and which parent field group their values should be loaded into when generating the backend form for entering values. I've tried a system where valueorder and suborder are used for these fields when saving data as a start. When it comes to parsing these columns within the table and using them to render the form, however, I’ve hit a roadblock. I’m not sure what step in the process these values should be sent to in a way that the loop for grouped_fields can read them and use them for value sorting. It also seems like the nested group fields are having issues saving their data.

One of the specific issues I've encountered is that when field groups are processed by fieldgroup.php in the backend, nested field groups processed first and when it comes time for their parent field group to add their form field display, their html attribute has already been imploded into a string. I want to pursue a method where the valueorder of the fields within that nested field group can help the parent field group determine which entries of the parent will have the appropriate values. The values of these fields also seem to not save properly, I think something is happening when the form saves that’s tripping it up but I’m not sure what.

Before testing these changes, be sure to add the respective columns to the flexicontent_fields table, otherwise the values for the fields that handle showing/hiding fields will not properly save and the functionality will not work in the backend:

- defaultviewbehavior - SMALLINT(8)
- Fieldviewbehavior - SMALLINT(8)
- checkfieldname - TEXT
- checkfieldvalue - TEXT

You will also need to refresh the form after filling out the field used to show/hide fields in item forms in order for the fields checking its value to show.

Thanks for any help you can give with helping to build this out and resolve the issues with it.