### PR TITLE
Match Joomla with puzzle icon

### DIFF
--- a/admin/views/field/view.html.php
+++ b/admin/views/field/view.html.php
@@ -154,8 +154,8 @@ class FlexicontentViewField extends FlexicontentViewBaseRecord
 
 		// SET toolbar title
 		!$isnew
-			? JToolbarHelper::title( JText::_( 'FLEXI_EDIT_FIELD' ), 'fieldedit' )
-			: JToolbarHelper::title( JText::_( 'FLEXI_ADD_FIELD' ), 'fieldadd' );
+			? JToolbarHelper::title( JText::_( 'FLEXI_EDIT_FIELD' ), 'puzzle' )
+			: JToolbarHelper::title( JText::_( 'FLEXI_ADD_FIELD' ), 'puzzle' );
 
 
 		/**

--- a/admin/views/fields/view.html.php
+++ b/admin/views/fields/view.html.php
@@ -151,7 +151,7 @@ class FlexicontentViewFields extends FlexicontentViewBaseRecords
 		// Create document/toolbar titles
 		$doc_title = JText::_( 'FLEXI_FIELDS' );
 		$site_title = $document->getTitle();
-		JToolbarHelper::title( $doc_title, 'fields' );
+		JToolbarHelper::title( $doc_title, 'puzzle' );
 		$document->setTitle($doc_title .' - '. $site_title);
 
 		// Create the toolbar


### PR DESCRIPTION
J! uses puzzel piece:
![](https://i.imgur.com/aXTIVax.png)

FLEXIcontent:
![image](https://github.com/FLEXIcontent/flexicontent-cck/assets/8617673/d796bc15-8fb6-4315-b297-665d212e6b76)

I feel Flexicontent should match and use [bolt](https://fontawesome.com/v5/search?q=bolt&o=r&m=free) for plugins.