### PR TITLE
Get Cleared field to display in backend

### DIFF
--- a/admin/views/item/tmpl/common/render_fields.php
+++ b/admin/views/item/tmpl/common/render_fields.php
@@ -1807,7 +1807,7 @@ if ($this->fields && $typeid) :
 
 				<?php ob_start(); /* label_html */ ?>
 				<div
-					class="control-label"
+					class="control-label<?php echo $display_label_form === 2 ? ' fclabel_cleared' : ''; ?>"
 					id="label_outer_fcfield_<?php echo $field->id; ?>"
 					style="<?php echo $display_label_form < 1 ? 'display:none;' : '' ?>"
 				>

--- a/admin/views/item/tmpl/common/render_fields.php
+++ b/admin/views/item/tmpl/common/render_fields.php
@@ -1803,11 +1803,11 @@ if ($this->fields && $typeid) :
 				' container_fcfield container_fcfield_id_' . $field->id . ' container_fcfield_name_' . $field->name;
 			?>
 
-			<div class="control-group">
+			<div class="control-group<?php echo $display_label_form === 2 ? ' fc_vertical' : ''; ?>">
 
 				<?php ob_start(); /* label_html */ ?>
 				<div
-					class="control-label <?php echo $display_label_form === 2 ? 'fclabel_cleared' : ''; ?>"
+					class="control-label"
 					id="label_outer_fcfield_<?php echo $field->id; ?>"
 					style="<?php echo $display_label_form < 1 ? 'display:none;' : '' ?>"
 				>


### PR DESCRIPTION
Cleared doesn't work in j4:
![img](https://i.imgur.com/VL1oRwJ.png)

This code fixes it.

![img](https://i.imgur.com/71mrSEM.png)

We also need some extra code LESS (/components/com_flexicontent/assets/less/flexi_shared.less) to make it work:

```
/* vertical form */
#flexicontent {
	.control-group {
		&.fc_vertical {
			-webkit-box-orient: vertical;
			-webkit-box-direction: normal;
				-ms-flex-direction: column;
					flex-direction: column;
	
					.label-fcinner {
						text-align: left;
						width: auto;
					}
		}
	}
}
```



