### PR TITLE
Bootstrap Alert fails in J4

### DIFF
--- a/admin/views/item/tmpl/common/load_config_n_acl.php
+++ b/admin/views/item/tmpl/common/load_config_n_acl.php
@@ -21,10 +21,11 @@ $this->menuCats = $isnew ? $this->menuCats : false;  // just make sure ...
 
 /**
  * Create reusable html code
+ * 
  */
 
-$close_btn = '<a class="close" data-dismiss="alert">&#215;</a>';  // '<a class="fc-close" onclick="this.parentNode.parentNode.removeChild(this.parentNode);">&#215;</a>';
-$alert_box = '<div %s class="alert alert-%s %s">'.$close_btn.'%s</div>';  // '<div %s class="fc-mssg fc-%s %s">'.$close_btn.'%s</div>';
+$close_btn = '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="'.JText::_('CLOSE').'"></button>';  // '<a class="fc-close" onclick="this.parentNode.parentNode.removeChild(this.parentNode);">&#215;</a>';
+$alert_box = '<div %s class="alert alert-%s %s alert-dismissible fade show" role="alert">'.$close_btn.'%s</div>';  // '<div %s class="fc-mssg fc-%s %s">'.$close_btn.'%s</div>';
 $btn_class = 'btn';  // 'fc_button';
 $tip_class = ' hasTooltip';
 $lbl_class = ' ' . $this->params->get('form_lbl_class' . $CFGsfx, '');

--- a/admin/views/item/tmpl/layouts/tabs/main.php
+++ b/admin/views/item/tmpl/layouts/tabs/main.php
@@ -3,6 +3,7 @@
 // ADD TOOLTIPS
 use Joomla\CMS\HTML\HTMLHelper;
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
+HTMLHelper::_('bootstrap.alert', '.alert-dismissable');
 
 /**
  * Placement configuration


### PR DESCRIPTION
If we set our editing help  field inline:

![](https://i.imgur.com/YSGkm69.png)

The alert close fails in j4:

![](https://i.imgur.com/JfKPpTP.png)

The code I have used fixes it:

![](https://i.imgur.com/FacqoVH.png)

