### PR TITLE
module manager Icons missing in J4

### DIFF
--- a/site/helpers/html/fclayoutbuilder.php
+++ b/site/helpers/html/fclayoutbuilder.php
@@ -341,10 +341,10 @@ abstract class JHtmlFclayoutbuilder
 		body {
 			overflow: scroll;
 		}
-		.fa, .fas, [class^=icon-], [class*=" icon-"] {
-			font-family: \'FontAwesome\';
-			font-weight: normal;
-		}
+		// .fa, .fas, [class^=icon-], [class*=" icon-"] {
+		// 	font-family: \'FontAwesome\';
+		// 	font-weight: normal;
+		// }
 		label.gjs-sm-icon {
 			color: #fff;
 		}


### PR DESCRIPTION
The module manager Icons missing in J4:

![](https://i.imgur.com/jmsWZv6.png)

As this code uses old code:

font-family: \'FontAwesome\';

Commenting it out seems to work:

![](https://i.imgur.com/K5Vu1Xb.png)