### PR TITLE
max_input_vars  4000

### DIFF
--- a/site/classes/helpers/html.php
+++ b/site/classes/helpers/html.php
@@ -132,7 +132,7 @@ class flexicontent_html
 	static function & checkPHPLimits($required=null, $recommended=null)
 	{
 		if (!$required)    $required=array('max_input_vars'=>1000, 'suhosin.post.max_vars'=>1000, 'suhosin.request.max_vars'=>1000);
-		if (!$recommended) $recommended=array('max_input_vars'=>2000, 'suhosin.post.max_vars'=>2000, 'suhosin.request.max_vars'=>2000);
+		if (!$recommended) $recommended=array('max_input_vars'=>4000, 'suhosin.post.max_vars'=>4000, 'suhosin.request.max_vars'=>4000);
 
 		$suhosin_loaded = extension_loaded('suhosin');
 		$result = array();


### PR DESCRIPTION
Hi,

FLEXIContent documentation states [4000 is the magic number for max_input_vars:](https://www.flexicontent.org/documentation/tutorials-english/78-installation-upgrade/591-php-db-requirements.html)

So - is it 2000 or 4000? 