### PR TITLE
Update value_default.php

### DIFF
--- a/plugins/flexicontent_fields/jprofile/tmpl/value_default.php
+++ b/plugins/flexicontent_fields/jprofile/tmpl/value_default.php
@@ -54,7 +54,7 @@ $n = 0;
 foreach ($values as $value)
 {
 	// Skip empty value, adding an empty placeholder if field inside in field group
-	if ( !strlen($value) )
+	if ( $value === null || !strlen($value) )
 	{
 		if ( $is_ingroup )
 		{


### PR DESCRIPTION
The same Issue of depreciation in 8.1

if ( $value === null || !strlen($value) )

PHP 7.4, strlen() can accept null values without issuing a deprecation notice.