### PR TITLE
Update flexicontent.fields.php

### DIFF
--- a/site/classes/flexicontent.fields.php
+++ b/site/classes/flexicontent.fields.php
@@ -3000,7 +3000,7 @@ class FlexicontentFields
 				}
 
 				// Check value is not empty
-				if ( !is_array($v) && !strlen($v) ) continue;
+				if ( !is_array($v) && !(is_string($v) && strlen($v)) ) continue;
 
 				// If has field 'required/search' properties, then check field is multi-property (value is array)
 				if ( !is_array($v) && (count($required_props) || count($search_props)) ) continue;
@@ -3012,7 +3012,7 @@ class FlexicontentFields
 				$required_exists = true;
 				foreach ($required_props as $cp)
 				{
-					if ( !strlen($v[$cp] ?? '') ) $required_exists = false;
+					if ( !(isset($v[$cp]) && strlen($v[$cp])) ) $required_exists = false;
 				}
 				if (!$required_exists) continue;
 


### PR DESCRIPTION
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in D:\2023-laragon\www\z\components\com_flexicontent\classes\flexicontent.fields.php on line 3003

PHP 8.1