### PR TITLE
Update flexisearch.php

### DIFF
--- a/plugins/search/flexisearch/flexisearch.php
+++ b/plugins/search/flexisearch/flexisearch.php
@@ -310,7 +310,7 @@ class plgSearchFlexisearch extends \Joomla\CMS\Plugin\CMSPlugin
 				.' i.language AS language,'
 				.' i.metakey AS metakey,'
 				.' i.metadesc AS metadesc,'
-				.' i.modified AS created,'     // TODO ADD a PARAMETER FOR CONTROLING the use of modified by or created by date as "created"
+				.' i.created AS created,'     // TODO ADD a PARAMETER FOR CONTROLING the use of modified by or created by date as "created"
 				.' c.title AS maincat_title, c.alias AS maincat_alias,'  // Main category data
 				.' t.name AS tagname,'
 				.' fir.value as field,'


### PR DESCRIPTION
modified returns wacky results as an item correction will bring the item back into the results but will always display its creation date. This is not consistent, much less for visitors who will not understand the results.