### PR TITLE
Pull Request: Fix PHP 8.3 FCRADIO Compatibility Issues

### DIFF
--- a/admin/elements/fcradio.php
+++ b/admin/elements/fcradio.php
@@ -53,7 +53,7 @@ class JFormFieldFcradio extends JFormFieldRadio
 	
 	function getInput()
 	{
-		$class = $this->element['class'];
+		$class = (string) $this->element['class'];
 		$isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
 		$isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
 		return $isBtnGroup && !$isBtnYesNo


### PR DESCRIPTION
Fixed trim() null parameter deprecation in fcradio.php
File: [fcradio.php](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Issue: trim() with null parameter is deprecated in PHP 8.1+
Solution: Cast to string to handle null values safely
Before: $class = $this->element['class'];
After: $class = (string) $this->element['class'];

<img width="1639" height="684" alt="image" src="https://github.com/user-attachments/assets/2428e7d9-965e-4c3d-bb9a-8ab601bc6f8f" />
