### PR TITLE
 Fix PHP 8.1+ trim() null parameter deprecation in fields view

### DIFF
--- a/admin/views/fields/view.html.php
+++ b/admin/views/fields/view.html.php
@@ -236,7 +236,8 @@ class FlexicontentViewFields extends FlexicontentViewBaseRecords
 			// Handle displaying information: FIELDGROUP feature
 			$row->parameters = new \Joomla\Registry\Registry($row->attribs);
 
-			$ingroup_fids = array_filter(preg_split('/[\s]*,[\s]*/', $row->parameters->get('fields')), function($v) { return (trim($v) !== ''); });
+			//$ingroup_fids = array_filter(preg_split('/[\s]*,[\s]*/', $row->parameters->get('fields')), function($v) { return (trim($v) !== ''); });
+			$ingroup_fids = array_filter(preg_split('/[\s]*,[\s]*/', $row->parameters->get('fields', '')), function($v) { return (trim((string)$v) !== ''); });
 			$ingroup_fids = ArrayHelper::toInteger($ingroup_fids);
 
 			// For fields of group that are included in current list, add reference to their group field

--- a/admin/views/fields/view.html.php
+++ b/admin/views/fields/view.html.php
@@ -207,7 +207,7 @@ class FlexicontentViewFields extends FlexicontentViewBaseRecords
 			// Find ids of master fields (if any)
 			if ($row->field_type === 'fieldgroup')
 			{
-				$FG_fieldids[$id] = array_filter(preg_split('/[\s]*,[\s]*/', $row->parameters->get('fields')), function($v) { return (trim($v) !== ''); });
+				$FG_fieldids[$id] = array_filter(preg_split('/[\s]*,[\s]*/', $row->parameters->get('fields', '')), function($v) { return (trim((string)$v) !== ''); });
 				$FG_fieldids[$id] = ArrayHelper::toInteger($FG_fieldids[$id]);
 
 				$grouped_fids = array_merge($grouped_fids, $FG_fieldids[$id]);


### PR DESCRIPTION
2 issues resolved:

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in 
.../administrator/components/com_flexicontent/views/fields/view.html.php on line 239
```
<img width="2289" height="79" alt="image" src="https://github.com/user-attachments/assets/462802bf-8328-4d48-a8b1-dd48637e8af2" />


File: [view.html.php](vscode-file://vscode-app/c:/Users/User/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (line 239)


After:

✅ Changes
Added default empty string to get('fields', '') to prevent null input to preg_split()
Cast $v to string with (string)$v before passing to trim()
🎯 Result
✅ Eliminates PHP 8.1+ deprecation warning
✅ Backward compatible with older PHP versions
✅ No functional changes to field group processing logic
Type: Bug Fix
Compatibility: PHP 8.1+ deprecation fix, backward compatible

This is a targeted fix for the specific trim() deprecation issue in the field group processing logic.