### PR TITLE
Update flexiadvsearch.php

### DIFF
--- a/plugins/search/flexiadvsearch/flexiadvsearch.php
+++ b/plugins/search/flexiadvsearch/flexiadvsearch.php
@@ -47,6 +47,20 @@ class plgSearchFlexiadvsearch extends \Joomla\CMS\Plugin\CMSPlugin
 	var $autoloadLanguage = false;
 
 	/**
+	 * Merged FLEXIcontent component and active menu parameters.
+	 *
+	 * @var \Joomla\Registry\Registry|null
+	 */
+	protected $_params = null;
+
+	/**
+	 * Current active search string.
+	 *
+	 * @var string|null
+	 */
+	protected $_active_search = null;
+
+	/**
 	 * Constructor
 	 *
 	 * @access      public


### PR DESCRIPTION
JCE’s link dialog is triggering Joomla search providers, and the FLEXIcontent search plugin plugins/search/flexiadvsearch/flexiadvsearch.php is still using PHP 8.2-incompatible dynamic properties.


`Deprecated: Creation of dynamic property plgSearchFlexiadvsearch::$_params is deprecated in ...plugins\search\flexiadvsearch\flexiadvsearch.php on line 65`

The specific problem was this class assigning to undeclared members:

$this->_params
$this->_active_search
On PHP 8.2+, that raises:
Creation of dynamic property ... is deprecated

Issue:
<img width="833" height="422" alt="image" src="https://github.com/user-attachments/assets/4c4c6f19-1c85-43ac-baaa-b6bcbc84293f" />

I can't save or open links with the depreciated notice - so this fixes it.