### PR TITLE
Fix jQuery Error message

### DIFF
--- a/plugins/system/flexisystem/flexisystem.php
+++ b/plugins/system/flexisystem/flexisystem.php
@@ -346,6 +346,7 @@ class plgSystemFlexisystem extends CMSPlugin
 				$suhosin_lim = ini_get('suhosin.request.max_vars');
 				if ($suhosin_lim < $max_input_vars) $max_input_vars = $suhosin_lim;
 			}
+			HTMLHelper::_('jquery.framework');
 			$js .= "
 				jQuery(document).ready(function() {
 					Joomla.fc_max_input_vars = ".$max_input_vars.";
@@ -361,7 +362,8 @@ class plgSystemFlexisystem extends CMSPlugin
 			$isAdmin && (
 			($option=='com_users' && ($view == 'user'))
 			)
-		)
+		) {
+			HTMLHelper::_('jquery.framework');
 			$js .= "
 				jQuery(document).ready(function() {
 					var el = parent.document.getElementById('fc_modal_popup_container');
@@ -371,6 +373,7 @@ class plgSystemFlexisystem extends CMSPlugin
 					}
 				});
 			";
+		}
 		if ($js) $document->addScriptDeclaration($js);
 
 
@@ -1970,8 +1973,8 @@ class plgSystemFlexisystem extends CMSPlugin
 
 	private function _storeLessConf($table)
 	{
-		$xml_path  = \Joomla\Filesystem\Path::clean(JPATH_ADMINISTRATOR.'/components/com_flexicontent/config.xml');
-		$less_path = \Joomla\Filesystem\Path::clean(JPATH_ROOT.'/components/com_flexicontent/assets/less/include/mixins.less');
+		$xml_path  = \Joomla\CMS\Filesystem\Path::clean(JPATH_ADMINISTRATOR.'/components/com_flexicontent/config.xml');
+		$less_path = \Joomla\CMS\Filesystem\Path::clean(JPATH_ROOT.'/components/com_flexicontent/assets/less/include/mixins.less');
 
 
 		/**


### PR DESCRIPTION
Load jQuery framework before injecting jQuery-based admin JS

The system plugin injects inline jQuery(document).ready() blocks on admin module-edit pages and com_users user-edit pages, but did not request the jQuery framework. On Joomla 5+ this throws "jQuery is not defined" because jQuery is no longer auto-loaded in admin and must be requested explicitly via `HTMLHelper::_('jquery.framework').`


```
<script>
jQuery(document).ready(function() {
Joomla.fc_max_input_vars = 1000;
jQuery(document.forms['adminForm']).attr('data-fc_doserialized_submit', '1');				
				});
			</script>
```