### PR TITLE
HTMLHelper::_('jquery.framework') fix for J6

### DIFF
--- a/plugins/system/flexisystem/flexisystem.php
+++ b/plugins/system/flexisystem/flexisystem.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package         FLEXIcontent
  * @version         3.3
@@ -32,8 +33,12 @@ use Joomla\CMS\User\UserHelper;
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Router\Route;
 
+
+
+
+
 if (!defined('DS'))  define('DS', DIRECTORY_SEPARATOR);
-require_once (JPATH_ADMINISTRATOR.'/components/com_flexicontent/defineconstants.php');
+require_once(JPATH_ADMINISTRATOR . '/components/com_flexicontent/defineconstants.php');
 JLoader::register('JHtmlFclayoutbuilder', JPATH_ROOT . '/components/com_flexicontent/helpers/html/fclayoutbuilder.php');
 
 /**
@@ -48,34 +53,30 @@ class plgSystemFlexisystem extends CMSPlugin
 	/**
 	 * Constructor
 	 */
-	function __construct( &$subject, $config )
+	function __construct(&$subject, $config)
 	{
-		parent::__construct( $subject, $config );
+		parent::__construct($subject, $config);
 
 		static $language_loaded = null;
 
-		if (!$language_loaded)
-		{
+		if (!$language_loaded) {
 			Factory::getApplication()->isClient('administrator')
 				? CMSPlugin::loadLanguage('plg_system_flexisystem_common_be', JPATH_ADMINISTRATOR)
 				: CMSPlugin::loadLanguage('plg_system_flexisystem_common_fe', JPATH_ADMINISTRATOR);
 		}
 
-		if (!$this->autoloadLanguage && $language_loaded === null)
-		{
+		if (!$this->autoloadLanguage && $language_loaded === null) {
 			$language_loaded = CMSPlugin::loadLanguage('plg_system_flexisystem', JPATH_ADMINISTRATOR);
 		}
 
 		$this->extension = 'com_flexicontent';
 		$this->cparams = ComponentHelper::getParams($this->extension);
-		if (!$this->cparams->get('bootstrap_ver', null))
-		{
+		if (!$this->cparams->get('bootstrap_ver', null)) {
 			$this->cparams->set('bootstrap_ver', (FLEXI_J40GE ? 5 : 2));
 		}
 
 		// Temporary workaround until code is updated
-		if (FLEXI_J40GE)
-		{
+		if (FLEXI_J40GE) {
 			Factory::getDbo()->setQuery(
 				"SET sql_mode=(SELECT REPLACE(REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''),'STRICT_TRANS_TABLES',''))"
 			)->execute();
@@ -101,8 +102,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		 * Call 'flexicontent' items model to update the featured FLAG, thus updating temporary data too
 		 */
 
-		if ($task === 'articles.featured' || $task === 'articles.unfeatured')
-		{
+		if ($task === 'articles.featured' || $task === 'articles.unfeatured') {
 			$this->_loadFcHelpersAndLanguage();
 
 			// Load the FLEXIcontent item
@@ -118,20 +118,17 @@ class plgSystemFlexisystem extends CMSPlugin
 		 * Call joomla configuration model to update to sync the permission between com_flexicontent and com_content
 		 */
 
-		elseif ($task === 'config.store')
-		{
+		elseif ($task === 'config.store') {
 			$comp = $app->input->get('comp', '', 'cmd');
 			$comp = str_replace('com_flexicontent.category.', 'com_content.category.', $comp);
 			$comp = str_replace('com_flexicontent.item.', 'com_content.article.', $comp);
 			$app->input->set('comp', $comp);
 
-			if ($comp === 'com_content' || $comp === 'com_flexicontent')
-			{
-				$skip_arr = array('core.admin'=>1, 'core.options'=>1, 'core.manage'=>1);
+			if ($comp === 'com_content' || $comp === 'com_flexicontent') {
+				$skip_arr = array('core.admin' => 1, 'core.options' => 1, 'core.manage' => 1);
 				$action = $app->input->get('action');
 
-				if (substr($action, 0, 5) == 'core.' && !isset($skip_arr[$action]))
-				{
+				if (substr($action, 0, 5) == 'core.' && !isset($skip_arr[$action])) {
 					$comp_other = $comp == 'com_content'  ?  'com_flexicontent'  :  'com_content';
 					$permissions = array(
 						'component' => $comp_other,
@@ -141,12 +138,11 @@ class plgSystemFlexisystem extends CMSPlugin
 						'title'     => $app->input->get('title', '', 'string')
 					);
 
-					JLoader::register('ConfigModelApplication', JPATH_ADMINISTRATOR.'/components/com_config/model/application.php');
-					JLoader::register('ConfigModelForm', JPATH_SITE.'/components/com_config/model/form.php');
-					JLoader::register('ConfigModelCms', JPATH_SITE.'/components/com_config/model/cms.php');
+					JLoader::register('ConfigModelApplication', JPATH_ADMINISTRATOR . '/components/com_config/model/application.php');
+					JLoader::register('ConfigModelForm', JPATH_SITE . '/components/com_config/model/form.php');
+					JLoader::register('ConfigModelCms', JPATH_SITE . '/components/com_config/model/cms.php');
 
-					if (!(substr($permissions['component'], -6) === '.false'))
-					{
+					if (!(substr($permissions['component'], -6) === '.false')) {
 						// Load Permissions from Session and send to Model
 						$model    = new ConfigModelApplication;
 						$response = $model->storePermissions($permissions);
@@ -170,32 +166,29 @@ class plgSystemFlexisystem extends CMSPlugin
 
 
 		// Clear categories cache if previous page has saved FC component configuration
-		if ( $session->get('clear_cats_cache', 0, 'flexicontent') )
-		{
+		if ($session->get('clear_cats_cache', 0, 'flexicontent')) {
 			$session->set('clear_cats_cache', 0, 'flexicontent');
 
 			// Clean cache
-			$cache = $this->getCache($group='', 0);
+			$cache = $this->getCache($group = '', 0);
 			$cache->clean('com_flexicontent');
 
-			$cache = $this->getCache($group='', 1);
+			$cache = $this->getCache($group = '', 1);
 			$cache->clean('com_flexicontent');
 
-			$cache = $this->getCache($group='', 0);
+			$cache = $this->getCache($group = '', 0);
 			$cache->clean('com_flexicontent_cats');
 
-			$cache = $this->getCache($group='', 1);
+			$cache = $this->getCache($group = '', 1);
 			$cache->clean('com_flexicontent_cats');
 
 			//Factory::getApplication()->enqueueMessage( "Cleaned CACHE groups: <b>com_flexicontent</b>, <b>com_flexicontent_cats</b>", 'message');
 		}
 
-		if (FLEXI_SECTION || FLEXI_CAT_EXTENSION)
-		{
+		if (FLEXI_SECTION || FLEXI_CAT_EXTENSION) {
 			global $globalcats;
 			$start_microtime = microtime(true);
-			if (FLEXI_CACHE)
-			{
+			if (FLEXI_CACHE) {
 				// Add the category tree to categories cache
 				$catscache = Factory::getCache('com_flexicontent_cats');
 				$catscache->setCaching(1);                  // Force cache ON
@@ -209,8 +202,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		}
 
 		// REMEMBER last value of the fcdebug parameter, and use it to enable statistics display
-		if ( $option==$this->extension && $this->cparams->get('print_logging_info')==1 )
-		{
+		if ($option == $this->extension && $this->cparams->get('print_logging_info') == 1) {
 			// Try request variable first then session variable
 			$fcdebug = $app->input->get('fcdebug', '', 'cmd');
 			$fcdebug = strlen($fcdebug) ? (int)$fcdebug : $session->get('fcdebug', 0, 'flexicontent');
@@ -221,7 +213,10 @@ class plgSystemFlexisystem extends CMSPlugin
 		}
 
 		$print_logging_info = $this->cparams->get('print_logging_info');
-		if ($print_logging_info) { global $fc_run_times; $start_microtime = microtime(true); }
+		if ($print_logging_info) {
+			global $fc_run_times;
+			$start_microtime = microtime(true);
+		}
 
 		// (a.1) (Auto) Check-in DB table records according to time limits set
 		$this->checkinRecords();
@@ -241,11 +236,9 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// (c) Route PDF format to HTML format for J1.6+
 		$redirect_pdf_format = $this->params->get('redirect_pdf_format', 1);
-		if ($redirect_pdf_format && $app->input->get('format', 'html', 'cmd') == 'pdf')
-		{
+		if ($redirect_pdf_format && $app->input->get('format', 'html', 'cmd') == 'pdf') {
 			$app->input->set('format', 'html');
-			if ($redirect_pdf_format==2)
-			{
+			if ($redirect_pdf_format == 2) {
 				Factory::getApplication()->enqueueMessage('PDF generation is not supported, the HTML version is displayed instead', 'notice');
 			}
 		}
@@ -271,22 +264,18 @@ class plgSystemFlexisystem extends CMSPlugin
 		// these are typically administrators and super admins roles
 		$hasTemplates = Factory::getUser()->authorise('core.admin', 'com_templates');
 
-		if ( !Factory::getApplication()->isClient('administrator'))
-		{
-			if ( !Factory::getUser()->authorise('core.admin') && (isset($_POST['jform']['params']['php_rule']) || isset($_REQUEST['jform']['params']['php_rule']) ))
-			{
+		if (!Factory::getApplication()->isClient('administrator')) {
+			if (!Factory::getUser()->authorise('core.admin') && (isset($_POST['jform']['params']['php_rule']) || isset($_REQUEST['jform']['params']['php_rule']))) {
 				Factory::getApplication()->enqueueMessage('You can not edit this in frontend. Please login as a super admin', 'warning');
 				Factory::getApplication()->redirect(Route::_('index.php'));
 			}
-		}
-
-		else if (!$hasTemplates)
-		{
-			if (isset($_POST['jform']['params']['php_rule']) || isset($_REQUEST['jform']['params']['php_rule']))
-			{
+		} else if (!$hasTemplates) {
+			if (isset($_POST['jform']['params']['php_rule']) || isset($_REQUEST['jform']['params']['php_rule'])) {
 				Factory::getApplication()->enqueueMessage(
 					'In order to avoid configuration loss, form was not saved.' .
-					' Templates privilege is need to save php code of the form', 'warning');
+						' Templates privilege is need to save php code of the form',
+					'warning'
+				);
 				Factory::getApplication()->redirect(Route::_('index.php'));
 			}
 		}
@@ -307,30 +296,27 @@ class plgSystemFlexisystem extends CMSPlugin
 		$tmpl   = $app->input->get('tmpl', '', 'string');
 		$task   = $app->input->get('task', '', 'string');  // NOTE during this event 'task' is (controller.task), thus we use filtering 'string'
 
-		$fcdebug = $this->cparams->get('print_logging_info')==2  ?  2  :  $session->get('fcdebug', 0, 'flexicontent');
+		$fcdebug = $this->cparams->get('print_logging_info') == 2  ?  2  :  $session->get('fcdebug', 0, 'flexicontent');
 		$isAdmin = Factory::getApplication()->isClient('administrator');
 
-		$isFC_Config = $isAdmin ? ($option=='com_config' && ($view == 'component' || $controller =='component') && $component == 'com_flexicontent')  :  false;
-		$isBE_Module_Edit = $isAdmin ? (($option =='com_modules' || $option =='com_advancedmodules') && $view == 'module')  :  false;
-		$isBE_Menu_Edit   = $isAdmin ? ($option =='com_menus' && $view == 'item' && $layout =='edit')  :  false;
+		$isFC_Config = $isAdmin ? ($option == 'com_config' && ($view == 'component' || $controller == 'component') && $component == 'com_flexicontent')  :  false;
+		$isBE_Module_Edit = $isAdmin ? (($option == 'com_modules' || $option == 'com_advancedmodules') && $view == 'module')  :  false;
+		$isBE_Menu_Edit   = $isAdmin ? ($option == 'com_menus' && $view == 'item' && $layout == 'edit')  :  false;
 
 		$js = '';
 
-		if ( $isBE_Module_Edit || $isBE_Menu_Edit )
-		{
-			Factory::getLanguage()->load($this->extension, JPATH_ADMINISTRATOR, 'en-GB'	, $_force_reload = false);
-			Factory::getLanguage()->load($this->extension, JPATH_ADMINISTRATOR, null		, $_force_reload = false);
+		if ($isBE_Module_Edit || $isBE_Menu_Edit) {
+			Factory::getLanguage()->load($this->extension, JPATH_ADMINISTRATOR, 'en-GB', $_force_reload = false);
+			Factory::getLanguage()->load($this->extension, JPATH_ADMINISTRATOR, null, $_force_reload = false);
 		}
 
 		if (
-			$isAdmin && ($isFC_Config || $isBE_Module_Edit) || ($option=='com_flexicontent' && ($isAdmin || $task == 'edit'))  // frontend task does not include 'controller.'
+			$isAdmin && ($isFC_Config || $isBE_Module_Edit) || ($option == 'com_flexicontent' && ($isAdmin || $task == 'edit'))  // frontend task does not include 'controller.'
 		) {
 			// WORKAROUNDs for slow chosen JS in component configuration form
-			if ($isFC_Config)
-			{
+			if ($isFC_Config) {
 				// Make sure chosen JS file is loaded before our code, but do not attach it to any elements (YET)
-				if (!FLEXI_J40GE)
-				{
+				if (!FLEXI_J40GE) {
 					// Do not run this in J4 , \Joomla\CMS\Document\Document not yet available, but chosen JS was replaced
 					HTMLHelper::_('formbehavior.chosen', '#_some_iiidddd_');
 				}
@@ -339,20 +325,27 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			// Add information for PHP 5.3.9+ 'max_input_vars' limit
 			$max_input_vars = ini_get('max_input_vars');
-			if (extension_loaded('suhosin'))
-			{
+			if (extension_loaded('suhosin')) {
 				$suhosin_lim = ini_get('suhosin.post.max_vars');
 				if ($suhosin_lim < $max_input_vars) $max_input_vars = $suhosin_lim;
 				$suhosin_lim = ini_get('suhosin.request.max_vars');
 				if ($suhosin_lim < $max_input_vars) $max_input_vars = $suhosin_lim;
 			}
-			HTMLHelper::_('jquery.framework');
+
+			$wa = Factory::getApplication()
+				->getDocument()
+				->getWebAssetManager();
+
+			$wa->useScript('jquery');
+			$wa->useScript('jquery-noconflict');
+
+
 			$js .= "
 				jQuery(document).ready(function() {
-					Joomla.fc_max_input_vars = ".$max_input_vars.";
-					".((JDEBUG || $fcdebug) ? 'Joomla.fc_debug = 1;' : '')."
+					Joomla.fc_max_input_vars = " . $max_input_vars . ";
+					" . ((JDEBUG || $fcdebug) ? 'Joomla.fc_debug = 1;' : '') . "
 					jQuery(document.forms['adminForm']).attr('data-fc_doserialized_submit', '1');
-					". /*(($option=='com_flexicontent' && $view='category') ? "jQuery(document.forms['adminForm']).attr('data-fc_force_apply_ajax', '1');" : "") .*/"
+					" . /*(($option=='com_flexicontent' && $view='category') ? "jQuery(document.forms['adminForm']).attr('data-fc_force_apply_ajax', '1');" : "") .*/ "
 				});
 			";
 		}
@@ -360,7 +353,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		// Hide Joomla administration menus in FC modals
 		if (
 			$isAdmin && (
-			($option=='com_users' && ($view == 'user'))
+				($option == 'com_users' && ($view == 'user'))
 			)
 		) {
 			HTMLHelper::_('jquery.framework');
@@ -378,8 +371,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 
 		// Detect resolution we will do this regardless of ... using mobile layouts
-		if ($this->cparams->get('use_mobile_layouts') || $app->isClient('administrator'))
-		{
+		if ($this->cparams->get('use_mobile_layouts') || $app->isClient('administrator')) {
 			$this->detectClientResolution($this->cparams);
 		}
 
@@ -405,8 +397,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$option = $app->input->get('option', '', 'cmd');
 
 		// Skip other components
-		if (empty($option) || ($option !== 'com_content'  && $option !== 'com_categories'))
-		{
+		if (empty($option) || ($option !== 'com_content'  && $option !== 'com_categories')) {
 			return;
 		}
 
@@ -418,14 +409,13 @@ class plgSystemFlexisystem extends CMSPlugin
 		/**
 		 * Exclude 'pagebreak' outputing dialog and Joomla article / category selection from a modal e.g. from a menu item, or from an editor
 		 */
-		if ($layout === 'pagebreak' || $layout === 'modal')
-		{
+		if ($layout === 'pagebreak' || $layout === 'modal') {
 			return;
 		}
 
 		// Split the task into 'controller' and task
 		$_ct = explode('.', $task);
-		$task = $_ct[ count($_ct) - 1];
+		$task = $_ct[count($_ct) - 1];
 		if (count($_ct) > 1) $controller = $_ct[0];
 
 		// Get user groups of current user
@@ -439,9 +429,8 @@ class plgSystemFlexisystem extends CMSPlugin
 		$excluded_urls = $this->params->get('excluded_redirect_urls', '');
 		$excluded_urls = preg_split("/[\s]*%%[\s]*/", $excluded_urls);
 
-		if (empty($excluded_urls[count($excluded_urls)-1]))
-		{
-			unset($excluded_urls[count($excluded_urls)-1]);
+		if (empty($excluded_urls[count($excluded_urls) - 1])) {
+			unset($excluded_urls[count($excluded_urls) - 1]);
 		}
 
 		// Get current URL
@@ -449,32 +438,28 @@ class plgSystemFlexisystem extends CMSPlugin
 
 
 		// First check excluded urls
-		foreach ($excluded_urls as $excluded_url)
-		{
+		foreach ($excluded_urls as $excluded_url) {
 			$quoted = preg_quote($excluded_url, "#");
-			if (preg_match("#$quoted#", $uri))
-			{
+			if (preg_match("#$quoted#", $uri)) {
 				return;
 			}
 		}
 
 
 		// if try to access com_content you get redirected to Flexicontent items
-		if ( $option === 'com_content' )
-		{
+		if ($option === 'com_content') {
 			// Check if a user group is groups, that are excluded from article redirection
-			if( count(array_intersect($usergroups, $exclude_arts)) ) return;
+			if (count(array_intersect($usergroups, $exclude_arts))) return;
 
 			// *** Specific Redirect Exclusions ***
 
 			//--. JA jatypo (editor-xtd plugin button for text style selecting)
-			if ($app->input->get('jatypo', '', 'cmd') && $layout=="edit") return;
+			if ($app->input->get('jatypo', '', 'cmd') && $layout == "edit") return;
 
 			//--. Allow listing featured backend management
-			if ($view=="featured") return;
+			if ($view == "featured") return;
 
-			switch ($task)
-			{
+			switch ($task) {
 				case 'add':
 					$redirectURL = 'index.php?option=' . $this->extension . '&task=items.add&cid=0';
 					break;
@@ -486,37 +471,31 @@ class plgSystemFlexisystem extends CMSPlugin
 					$redirectURL = 'index.php?option=' . $this->extension . '&view=itemelement&tmpl=component&object=' . $app->input->get('object', '');
 					break;
 				default:
-					if (!$task)
-					{
+					if (!$task) {
 						$redirectURL = 'index.php?option=' . $this->extension . '&view=items';
 					}
 					break;
 			}
-		}
-
-		elseif ( $option === 'com_categories' )
-		{
+		} elseif ($option === 'com_categories') {
 			// Check if a user group is groups, that are excluded from category redirection
-			if( count(array_intersect($usergroups, $exclude_cats)) ) return;
+			if (count(array_intersect($usergroups, $exclude_cats))) return;
 
 			// Get request variables used to determine whether to apply redirection
 			$category_scope = $app->input->get('extension', '', 'cmd');
 
 			// Apply redirection only if in com_categories is in content scope
-			if ( $category_scope !== 'com_content' ) return;
+			if ($category_scope !== 'com_content') return;
 
-			switch ($task)
-			{
+			switch ($task) {
 				case 'add':
-					$redirectURL = 'index.php?option=' . $this->extension . '&task=category.add&extension='.$this->extension;
+					$redirectURL = 'index.php?option=' . $this->extension . '&task=category.add&extension=' . $this->extension;
 					break;
 				case 'edit':
 					$cid = $app->input->get('id', $app->input->get('cid', 0));
-					$redirectURL = 'index.php?option=' . $this->extension . '&task=category.edit&cid='.intval(is_array($cid) ? $cid[0] : $cid);
+					$redirectURL = 'index.php?option=' . $this->extension . '&task=category.edit&cid=' . intval(is_array($cid) ? $cid[0] : $cid);
 					break;
 				default:
-					if (!$task)
-					{
+					if (!$task) {
 						$redirectURL = 'index.php?option=' . $this->extension . '&view=categories';
 					}
 					break;
@@ -524,8 +503,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		}
 
 		// Apply redirection
-		if (!empty($redirectURL))
-		{
+		if (!empty($redirectURL)) {
 			$app->redirect($redirectURL);
 		}
 	}
@@ -555,13 +533,12 @@ class plgSystemFlexisystem extends CMSPlugin
 		//***
 
 		$check_redirect = $option === 'com_content' && !$task && (
-				$view === 'article'  ||  // a. CASE :  com_content ARTICLE VIEW
-				$view === 'item'     ||  // b. CASE :  com_flexicontent ITEM VIEW / ITEM FORM link with com_content active menu item
-				$view === 'form'         // c. CASE :  com_content ARTICLE FORM
-			);
+			$view === 'article'  ||  // a. CASE :  com_content ARTICLE VIEW
+			$view === 'item'     ||  // b. CASE :  com_flexicontent ITEM VIEW / ITEM FORM link with com_content active menu item
+			$view === 'form'         // c. CASE :  com_content ARTICLE FORM
+		);
 
-		if (!$check_redirect)
-		{
+		if (!$check_redirect) {
 			return;
 		}
 
@@ -572,14 +549,12 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// In case of form we need to use a_id instead of id, this will also be set in HTTP Request too and \Joomla\CMS\Router\Router too
 		$id = $app->input->get('id', 0, 'int');
-		$id = ($view=='form') ? $app->input->get('a_id', 0, 'int') : $id;
+		$id = ($view == 'form') ? $app->input->get('a_id', 0, 'int') : $id;
 
 
 		// Allow new article form if so configured
-		if (!$id && $view !== 'item')
-		{
-			if ($this->cparams->get('jarticle_allow_new_form', 1))
-			{
+		if (!$id && $view !== 'item') {
+			if ($this->cparams->get('jarticle_allow_new_form', 1)) {
 				return;
 			}
 		}
@@ -592,33 +567,25 @@ class plgSystemFlexisystem extends CMSPlugin
 		//*** First Check if within 'FLEXIcontent' category subtree
 		//***
 
-		if ($catid)
-		{
+		if ($catid) {
 			$db->setQuery('SELECT lft, rgt FROM #__categories WHERE id = ' . $catid);
 			$cat_info = $db->loadObject();
 
-			if ($cat_info)
-			{
+			if ($cat_info) {
 				$cat_lft = $cat_info->lft;
 				$cat_rgt = $cat_info->rgt;
-			}
-
-			elseif ($id)
-			{
+			} elseif ($id) {
 				$db->setQuery('SELECT catid FROM #__content WHERE id = ' . $id);
 				$main_catid = $db->loadResult();
 
 				$db->setQuery('SELECT lft, rgt FROM #__categories WHERE id = ' . $main_catid);
 				$cat_info = $db->loadObject();
 
-				if ($cat_info)
-				{
+				if ($cat_info) {
 					$cat_lft = $cat_info->lft;
 					$cat_rgt = $cat_info->rgt;
 					$catid = $main_catid;
-				}
-				else
-				{
+				} else {
 					$catid = 0;
 				}
 			}
@@ -631,8 +598,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		// *** Allow Joomla article view for non-bound items or for specific content types (also
 		// ***
 
-		if ($in_limits)
-		{
+		if ($in_limits) {
 			$db->setQuery('SELECT attribs'
 				. ' FROM #__flexicontent_types AS ty '
 				. ' JOIN #__flexicontent_items_ext AS ie ON ie.type_id = ty.id '
@@ -640,8 +606,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			$type_params = $db->loadResult();
 
 			// If not found then article is not bound to a FLEXIcontent type yet
-			if ($type_params)
-			{
+			if ($type_params) {
 				$type_params = new Registry($type_params);
 			}
 		}
@@ -657,8 +622,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		// *** Joomla article view / form allowed
 		// ***
 
-		if ($allow_jview === 1)
-		{
+		if ($allow_jview === 1) {
 			return;
 		}
 
@@ -667,18 +631,16 @@ class plgSystemFlexisystem extends CMSPlugin
 		// *** Do re-routing (no page reloading)
 		// ***
 
-		elseif ($allow_jview === 0)
-		{
+		elseif ($allow_jview === 0) {
 			// Set new request variables
 			// NOTE: we only need to set HTTP request variable that must be changed, but setting any other variables to same value will not hurt
-			switch ($view)
-			{
+			switch ($view) {
 				case 'article':  // a. CASE :  com_content ARTICLE link that is rerouted to its corresponding flexicontent link
 				case 'item':     // b. CASE :  com_flexicontent ITEM VIEW / ITEM FORM link with com_content active menu item
 					$newRequest = array('option' => $this->extension, 'view' => 'item', 'Itemid' => $app->input->get('Itemid', null, 'int'), 'lang' => $app->input->get('lang', null, 'cmd'));
 					break;
 				case 'form':     // c. CASE :  com_content link to article edit form
-					$newRequest = array ('option' => $this->extension, 'view' => 'item', 'task'=>'edit', 'layout'=>'form', 'id' => $id, 'Itemid' => $app->input->get('Itemid', null, 'int'), 'lang' => $app->input->get('lang', null, 'cmd'));
+					$newRequest = array('option' => $this->extension, 'view' => 'item', 'task' => 'edit', 'layout' => 'form', 'id' => $id, 'Itemid' => $app->input->get('Itemid', null, 'int'), 'lang' => $app->input->get('lang', null, 'cmd'));
 					break;
 				default:
 					// Unknown CASE ?? unreachable ?
@@ -687,8 +649,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			//$app->enqueueMessage( "Set com_flexicontent item view instead of com_content article view", 'message');
 
 			// Set variables in the HTTP request
-			foreach($newRequest as $k => $v)
-			{
+			foreach ($newRequest as $k => $v) {
 				$app->input->set($k, $v);
 			}
 
@@ -703,18 +664,14 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		else  // $allow_jview === 2
 		{
-			if ($view === 'form')
-			{
-				$urlItem = 'index.php?option=' . $this->extension . '&view=item&id='.$id.'&task=edit';
-			}
-
-			else
-			{
+			if ($view === 'form') {
+				$urlItem = 'index.php?option=' . $this->extension . '&view=item&id=' . $id . '&task=edit';
+			} else {
 				// Include the route helper files
 				FLEXI_J40GE
-					? require_once (JPATH_SITE.'/components/com_content/src/Helper/RouteHelper.php')
-					: require_once (JPATH_SITE.'/components/com_content/helpers/route.php');
-				require_once (JPATH_SITE.'/components/com_flexicontent/helpers/route.php');
+					? require_once(JPATH_SITE . '/components/com_content/src/Helper/RouteHelper.php')
+					: require_once(JPATH_SITE . '/components/com_content/helpers/route.php');
+				require_once(JPATH_SITE . '/components/com_flexicontent/helpers/route.php');
 
 				$itemslug	= $app->input->get('id', '', 'string');
 				$catslug	= $app->input->get('catid', '', 'string');
@@ -752,8 +709,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			. '  CASE WHEN CHAR_LENGTH(c.alias) THEN CONCAT_WS(\':\', c.id, c.alias) ELSE c.id END AS slug, 0 AS numitems'
 			. ' FROM #__categories as c'
 			. ' WHERE c.extension=' . $db->Quote(FLEXI_CAT_EXTENSION) . ' AND c.lft > ' . $db->Quote(FLEXI_LFT_CATEGORY) . ' AND c.rgt < ' . $db->Quote(FLEXI_RGT_CATEGORY)
-			. ' ORDER BY c.parent_id, c.lft'
-		;
+			. ' ORDER BY c.parent_id, c.lft';
 		$cats = $db->setQuery($query)->loadObjectList('id');
 
 		// Get total active items for every category
@@ -765,11 +721,9 @@ class plgSystemFlexisystem extends CMSPlugin
 			. '  AND ( i.publish_up IS NULL OR i.publish_up = ' . $db->Quote($nullDate) . ' OR i.publish_up <= ' . $_nowDate . ' )'
 			. '  AND ( i.publish_down IS NULL OR i.publish_down = ' . $db->Quote($nullDate) . ' OR i.publish_down >= ' . $_nowDate . ' )'
 			. ' WHERE c.extension=' . $db->Quote(FLEXI_CAT_EXTENSION) . ' AND c.lft > ' . $db->Quote(FLEXI_LFT_CATEGORY) . ' AND c.rgt < ' . $db->Quote(FLEXI_RGT_CATEGORY)
-			. ' GROUP BY c.id'
-		;
+			. ' GROUP BY c.id';
 		$cat_totals = $db->setQuery($query)->loadObjectList('id');
-		foreach($cat_totals as $cat_id => $cat_total)
-		{
+		foreach ($cat_totals as $cat_id => $cat_total) {
 			$cats[$cat_id]->numitems = $cat_total->numitems;
 		}
 
@@ -780,8 +734,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		//set depth limit
 		$levellimit = 30;
 
-		foreach ($cats as $child)
-		{
+		foreach ($cats as $child) {
 			$parent = $child->parent_id;
 			if ($parent) $parents[] = $parent;
 			$list = @$children[$parent] ? $children[$parent] : array();
@@ -792,10 +745,9 @@ class plgSystemFlexisystem extends CMSPlugin
 		$parents = array_unique($parents);
 
 		//get list of the items
-		$globalcats = plgSystemFlexisystem::_getCatAncestors($ROOT_CATEGORY_ID, '', array(), $children, true, max(0, $levellimit-1));
+		$globalcats = plgSystemFlexisystem::_getCatAncestors($ROOT_CATEGORY_ID, '', array(), $children, true, max(0, $levellimit - 1));
 
-		foreach ($globalcats as $cat)
-		{
+		foreach ($globalcats as $cat) {
 			$cat->ancestorsonlyarray = $cat->ancestors;
 			$cat->ancestorsonly      = implode(',', $cat->ancestors);
 			$cat->ancestors[]        = $cat->id;
@@ -824,47 +776,36 @@ class plgSystemFlexisystem extends CMSPlugin
 	 * @access private
 	 * @return array
 	 */
-	static private function _getCatAncestors( $parent_id, $indent, $list, &$children, $title, $maxlevel=9999, $level=0, $type=1, $ancestors=null )
+	static private function _getCatAncestors($parent_id, $indent, $list, &$children, $title, $maxlevel = 9999, $level = 0, $type = 1, $ancestors = null)
 	{
 		$ROOT_CATEGORY_ID = 1;
 		if (!$ancestors) $ancestors = array();
 
-		if (!empty($children[$parent_id]) && $level <= $maxlevel)
-		{
-			foreach ($children[$parent_id] as $v)
-			{
+		if (!empty($children[$parent_id]) && $level <= $maxlevel) {
+			foreach ($children[$parent_id] as $v) {
 				$id = $v->id;
 
-				if ((!in_array($v->parent_id, $ancestors)) && $v->parent_id != $ROOT_CATEGORY_ID)
-				{
+				if ((!in_array($v->parent_id, $ancestors)) && $v->parent_id != $ROOT_CATEGORY_ID) {
 					$ancestors[] = $v->parent_id;
 				}
 
 				// Top level category (a child of ROOT)
-				if ($v->parent_id==1)
-				{
+				if ($v->parent_id == 1) {
 					$pre    = '';
 					$spacer = ' . ';
-				}
-				elseif ($type)
-				{
+				} elseif ($type) {
 					$pre    = '<sup>|_</sup> ';
 					$spacer = ' . ';
-				}
-				else
-				{
+				} else {
 					$pre    = '- ';
 					$spacer = ' . ';
 				}
 
-				if ($title)
-				{
+				if ($title) {
 					$txt = $v->parent_id == $ROOT_CATEGORY_ID
 						? '' . $v->title
 						: $pre . $v->title;
-				}
-				else
-				{
+				} else {
 					$txt = $v->parent_id == $ROOT_CATEGORY_ID
 						? ''
 						: $pre;
@@ -883,7 +824,15 @@ class plgSystemFlexisystem extends CMSPlugin
 
 				$parent_id = $id;
 				$list = plgSystemFlexisystem::_getCatAncestors(
-					$parent_id, $indent . $spacer, $list, $children, $title, $maxlevel, $level+1, $type, $ancestors
+					$parent_id,
+					$indent . $spacer,
+					$list,
+					$children,
+					$title,
+					$maxlevel,
+					$level + 1,
+					$type,
+					$ancestors
 				);
 			}
 		}
@@ -905,17 +854,14 @@ class plgSystemFlexisystem extends CMSPlugin
 		$stack = array();
 		$stack[] = $cat;
 
-		while( count($stack) )
-		{
+		while (count($stack)) {
 			$v = array_pop($stack);
 			$descendants[] = $v->id;
 
-			if ( empty($v->childrenarray) )
-			{
+			if (empty($v->childrenarray)) {
 				continue;
 			}
-			foreach( array_reverse($v->childrenarray) as $child )
-			{
+			foreach (array_reverse($v->childrenarray) as $child) {
 				$stack[] = $child;
 			}
 		}
@@ -938,17 +884,14 @@ class plgSystemFlexisystem extends CMSPlugin
 		$stack = array();
 		$stack[] = $cat;
 
-		while( count($stack) )
-		{
+		while (count($stack)) {
 			$v = array_pop($stack);
 			$totalItems += $v->numitems;
 
-			if ( empty($v->childrenarray) )
-			{
+			if (empty($v->childrenarray)) {
 				continue;
 			}
-			foreach( $v->childrenarray as $child )
-			{
+			foreach ($v->childrenarray as $child) {
 				$stack[] = $child;
 			}
 		}
@@ -976,9 +919,10 @@ class plgSystemFlexisystem extends CMSPlugin
 		$component = $app->input->get('component', '', 'cmd');
 		$task      = $app->input->get('task', '', 'cmd');
 
-		if ( $option == 'com_config' && $component == $this->extension &&
-			($task == 'apply' || $task == 'save' || $task == 'component.apply' || $task == 'component.save' || $task == 'config.save.component.apply' || $task == 'config.save.component.save') )
-		{
+		if (
+			$option == 'com_config' && $component == $this->extension &&
+			($task == 'apply' || $task == 'save' || $task == 'component.apply' || $task == 'component.save' || $task == 'config.save.component.apply' || $task == 'config.save.component.save')
+		) {
 			// Indicate that next page load will clean categories cache so that cache configuration will be recalculated
 			// (we will not do this at this step, because new component configuration has not been saved yet)
 			$session->set('clear_cats_cache', 1, 'flexicontent');
@@ -993,8 +937,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		//echo count($_REQUEST, COUNT_RECURSIVE); exit;
 
 		// Workaround for max_input_vars limitation (PHP 5.3.9+)
-		if ( !empty($_POST['fcdata_serialized']) )
-		{
+		if (!empty($_POST['fcdata_serialized'])) {
 			$app     = Factory::getApplication();
 
 			//parse_str($_POST['fcdata_serialized'], $form_data);  // Combined with "jQuery.serialize()", but cannot be used to overcome 'max_input_vars'
@@ -1003,12 +946,11 @@ class plgSystemFlexisystem extends CMSPlugin
 			//$form_data_e = $this->parse_json_decode_eval( $_POST['fcdata_serialized'], $total_vars_e );
 
 			$total_vars = null;
-			$form_data = $this->parse_json_decode( $_POST['fcdata_serialized'], $total_vars );
+			$form_data = $this->parse_json_decode($_POST['fcdata_serialized'], $total_vars);
 
 			//echo "<pre>"; print_r( $this->array_diff_recursive($form_data_e, $form_data) );  echo "</pre>"; exit;
 
-			foreach($form_data as $n => $v)
-			{
+			foreach ($form_data as $n => $v) {
 				$_POST[$n] = $v;
 				$_REQUEST[$n] = $v;
 				$app->input->post->set($n, $v);
@@ -1020,10 +962,10 @@ class plgSystemFlexisystem extends CMSPlugin
 			}*/
 
 			if (JDEBUG) Factory::getApplication()->enqueueMessage(
-				"Form data were serialized, ".
-				'<b class="label">PHP max_input_vars</b> <span class="badge bg-info badge-info">'.ini_get('max_input_vars').'</span> '.
-				'<b class="label">Estimated / Actual FORM variables</b>'.
-				'<span class="badge bg-warning badge-warning">'.$_POST['fcdata_serialized_count'].'</span> / <span class="badge">'.$total_vars.'</span> ',
+				"Form data were serialized, " .
+					'<b class="label">PHP max_input_vars</b> <span class="badge bg-info badge-info">' . ini_get('max_input_vars') . '</span> ' .
+					'<b class="label">Estimated / Actual FORM variables</b>' .
+					'<span class="badge bg-warning badge-warning">' . $_POST['fcdata_serialized_count'] . '</span> / <span class="badge">' . $total_vars . '</span> ',
 				'message'
 			);
 		}
@@ -1051,22 +993,20 @@ class plgSystemFlexisystem extends CMSPlugin
 		$db = Factory::getDbo();
 		$query 	= 'SELECT id, password'
 			. ' FROM #__users'
-			. ' WHERE username = ' . $db->Quote( $username )
-			. ' AND password = ' . $db->Quote( $password )
-		;
-		$db->setQuery( $query );
+			. ' WHERE username = ' . $db->Quote($username)
+			. ' AND password = ' . $db->Quote($password);
+		$db->setQuery($query);
 		$result = $db->loadObject();
 
-		if($result)
-		{
+		if ($result) {
 			PluginHelper::importPlugin('user');
 			$response = new stdClass();
 			$response->username = $username;
 			$response->password = $password;
 			$response->language = '';
-			$options = FLEXI_J16GE ? array('action'=>'core.login.site') : $options = array('action'=>'');
+			$options = FLEXI_J16GE ? array('action' => 'core.login.site') : $options = array('action' => '');
 			$loginEvent = FLEXI_J16GE ? 'onUserLogin' : 'onLoginUser';
-			$result = $app->triggerEvent($loginEvent, array((array)$response,$options));
+			$result = $app->triggerEvent($loginEvent, array((array)$response, $options));
 		}
 
 		return;
@@ -1087,8 +1027,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$session = Factory::getSession();
 		$format  = $app->input->getCmd('format', 'html');
 
-		if ($app->isClient('site') && $format === 'html')
-		{
+		if ($app->isClient('site') && $format === 'html') {
 			// Count an item or category hit if appropriate
 			$this->countHit();
 
@@ -1101,41 +1040,30 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			$view = $app->input->getCmd('view');
 
-			if ($view === 'item')
-			{
-				if ($id = $app->input->get('id', 0, 'int'))            $css[] = "item-id-".$id;  // Item's id
-				if ($cid = $app->input->get('cid', 0, 'int'))          $css[] = "item-catid-".$cid;  // Item's category id
-				if ($id)
-				{
+			if ($view === 'item') {
+				if ($id = $app->input->get('id', 0, 'int'))            $css[] = "item-id-" . $id;  // Item's id
+				if ($cid = $app->input->get('cid', 0, 'int'))          $css[] = "item-catid-" . $cid;  // Item's category id
+				if ($id) {
 					$db = Factory::getDbo();
 					$query 	= 'SELECT t.id, t.alias'
 						. ' FROM #__flexicontent_items_ext AS e'
 						. ' JOIN #__flexicontent_types AS t ON e.type_id = t.id'
-						. ' WHERE e.item_id=' . (int) $id
-					;
+						. ' WHERE e.item_id=' . (int) $id;
 					$type = $db->setQuery($query)->loadObject();
-					if ($type)
-					{
-						$css[] = "type-id-".$type->id;        // Type's id
-						$css[] = "type-alias-".$type->alias;  // Type's alias
+					if ($type) {
+						$css[] = "type-id-" . $type->id;        // Type's id
+						$css[] = "type-alias-" . $type->alias;  // Type's alias
 					}
 				}
-			}
-
-			elseif ($view === 'category')
-			{
+			} elseif ($view === 'category') {
 				// Category id
-				if ($cid = $app->input->get('cid', 0, 'int'))
-				{
+				if ($cid = $app->input->get('cid', 0, 'int')) {
 					$cid = is_array($cid) ? (int) reset($cid) : (int) $cid;
 
-					if ($cid)
-					{
+					if ($cid) {
 						$css[] = 'catid-' . $cid;
 					}
-				}
-				elseif ($cids = $app->input->get('cids', array(), 'array'))
-				{
+				} elseif ($cids = $app->input->get('cids', array(), 'array')) {
 					$catids = !is_array($cids)
 						? preg_split("/[\s]*,[\s]*/", $cids)
 						: $cids;
@@ -1144,20 +1072,19 @@ class plgSystemFlexisystem extends CMSPlugin
 					$css[] = 'mcats-' . implode(' mcats-', $catids);
 				}
 
-				if ($authorid = $app->input->get('authorid', 0, 'int'))  $css[] = "authorid-".$authorid; // Author id
-				if ($tagid = $app->input->get('tagid', 0, 'int'))        $css[] = "tagid-".$tagid;  // Tag id
-				if ($layout = $app->input->get('layout', '', 'cmd'))     $css[] = "cat-layout-".$layout;   // Category 'layout': tags, favs, author, myitems, mcats
+				if ($authorid = $app->input->get('authorid', 0, 'int'))  $css[] = "authorid-" . $authorid; // Author id
+				if ($tagid = $app->input->get('tagid', 0, 'int'))        $css[] = "tagid-" . $tagid;  // Tag id
+				if ($layout = $app->input->get('layout', '', 'cmd'))     $css[] = "cat-layout-" . $layout;   // Category 'layout': tags, favs, author, myitems, mcats
 			}
 
 			$html = $app->getBody();
-			$html = preg_replace('#<body([^>]*)class="#', '<body\1class="'.implode(' ', $css).' ', $html, 1);  // limit to ONCE !!
+			$html = preg_replace('#<body([^>]*)class="#', '<body\1class="' . implode(' ', $css) . ' ', $html, 1);  // limit to ONCE !!
 			$app->setBody($html);
 			$body_css_time = round(1000000 * 10 * (microtime(true) - $start_microtime)) / 10;
 		}
 
 		// If this is reached we now that the code for setting screen cookie has been added
-		if ($session->get('screenSizeCookieToBeAdded', 0, 'flexicontent'))
-		{
+		if ($session->get('screenSizeCookieToBeAdded', 0, 'flexicontent')) {
 			$session->set('screenSizeCookieTried', 1, 'flexicontent');
 			$session->set('screenSizeCookieToBeAdded', 0, 'flexicontent');
 		}
@@ -1165,8 +1092,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		// Add performance message at document's end
 		global $fc_performance_msg;
 
-		if ($fc_performance_msg && $format === 'html')
-		{
+		if ($fc_performance_msg && $format === 'html') {
 			$html = $app->getBody();
 
 			$inline_js_close_btn = !FLEXI_J30GE ? 'onclick="this.parentNode.parentNode.removeChild(this.parentNode);"' : '';
@@ -1174,12 +1100,14 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			$_replace_ = strpos($html, '<!-- fc_perf -->') ? '<!-- fc_perf -->' : '</body>';
 
-			$html = str_replace($_replace_,
-				'<div id="fc_perf_box" class="fc-mssg fc-info">'.
-				'<a class="close" data-dismiss="alert" '.$inline_js_close_btn.' style="'.$inline_css_close_btn.'" >&#215;</a>'.
-				(!empty($body_css_time) ? sprintf('** [Flexisystem PLG: Adding css classes to BODY: %.3f s]<br/>', $body_css_time/1000000) : '').
-				$fc_performance_msg.
-				'</div>'."\n".$_replace_, $html
+			$html = str_replace(
+				$_replace_,
+				'<div id="fc_perf_box" class="fc-mssg fc-info">' .
+					'<a class="close" data-dismiss="alert" ' . $inline_js_close_btn . ' style="' . $inline_css_close_btn . '" >&#215;</a>' .
+					(!empty($body_css_time) ? sprintf('** [Flexisystem PLG: Adding css classes to BODY: %.3f s]<br/>', $body_css_time / 1000000) : '') .
+					$fc_performance_msg .
+					'</div>' . "\n" . $_replace_,
+				$html
 			);
 
 			$app->setBody($html);
@@ -1200,28 +1128,27 @@ class plgSystemFlexisystem extends CMSPlugin
 		$app = Factory::getApplication();
 		$format = $app->input->get('format', 'html', 'cmd');
 
-		if (!$app->isClient('administrator') || !Factory::getUser()->id || $format !== 'html')
-		{
+		if (!$app->isClient('administrator') || !Factory::getUser()->id || $format !== 'html') {
 			return;
 		}
 
-		require_once (JPATH_SITE.'/components/com_flexicontent/helpers/permission.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/helpers/permission.php');
 		$perms = FlexicontentHelperPerm::getPerm();
 
 		Factory::getDocument()->addScriptDeclaration("
 			document.addEventListener('DOMContentLoaded', function(){
-				".(!$perms->CanReviews ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=reviews"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanCats    ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=categories"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanTypes   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=types"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanFields  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=fields"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanTags    ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=tags"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanTemplates ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=templates"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanAuthors ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=users"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanGroups  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=groups"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanFiles   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=filemanager"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanImport  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=import"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanStats   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=stats"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
-				".(!$perms->CanConfig  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_config&view=component&component=com_flexicontent"]\').forEach(function(element) { element.parentNode.remove(); });' : '')."
+				" . (!$perms->CanReviews ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=reviews"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanCats    ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=categories"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanTypes   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=types"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanFields  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=fields"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanTags    ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=tags"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanTemplates ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=templates"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanAuthors ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=users"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanGroups  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=groups"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanFiles   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=filemanager"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanImport  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=import"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanStats   ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_flexicontent&view=stats"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
+				" . (!$perms->CanConfig  ? 'document.querySelectorAll(\'#menu a[href="index.php?option=com_config&view=component&component=com_flexicontent"]\').forEach(function(element) { element.parentNode.remove(); });' : '') . "
 			});
 		");
 	}
@@ -1234,8 +1161,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$option = $app->input->get('option', '', 'cmd');
 		$browser_cachable = $app->input->get('browser_cachable', null);
 
-		if ($option==$this->extension && $browser_cachable!==null)
-		{
+		if ($option == $this->extension && $browser_cachable !== null) {
 			// Use 1/4 of Joomla cache time for the browser caching
 			$cachetime = (int) Factory::getConfig()->get('cachetime', 15);
 			$cachetime = $cachetime > 60 ? 60 : ($cachetime < 15 ? 15 : $cachetime);
@@ -1244,7 +1170,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			// Try to avoid browser warning message "Page has expired or similar"
 			// This should turning off the 'must-revalidate' directive in the 'Cache-Control' header
 			$app->allowCache($browser_cachable ? true : false);
-			$app->setHeader('Pragma', $browser_cachable ? '' :'no-cache');
+			$app->setHeader('Pragma', $browser_cachable ? '' : 'no-cache');
 
 			// CONTROL INTERMEDIARY CACHES (PROXY, ETC)
 			// 1:  public content (unlogged user),   2:  private content (logged user)
@@ -1253,7 +1179,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			// SET MAX-AGE, to allow modern browsers to cache the page, despite expires header in the past
 			$cacheControl .= ', max-age=300';
-			$app->setHeader('Cache-Control', $cacheControl );
+			$app->setHeader('Cache-Control', $cacheControl);
 
 			// Make sure no legacy proxies any caching !
 			$app->setHeader('Expires', 'Fri, 01 Jan 1990 00:00:00 GMT');
@@ -1275,32 +1201,32 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// Get session variables
 		$fc_screen_resolution  = $session->get('fc_screen_resolution', null, 'flexicontent');
-		if ( $fc_screen_resolution!==null) return;
+		if ($fc_screen_resolution !== null) return;
 
 
 		// Screen resolution is known after second reload or when user revisits our website
 
-		if ( isset($_COOKIE["fc_screen_resolution"]) ) {
+		if (isset($_COOKIE["fc_screen_resolution"])) {
 			$fc_screen_resolution = $_COOKIE["fc_screen_resolution"];
-			list($fc_screen_width,$fc_screen_height) = explode("x", $fc_screen_resolution);
+			list($fc_screen_width, $fc_screen_height) = explode("x", $fc_screen_resolution);
 			$session->set('fc_screen_resolution', $fc_screen_resolution, 'flexicontent');
 			$session->set('fc_screen_width', $fc_screen_width, 'flexicontent');
 			$session->set('fc_screen_height', $fc_screen_height, 'flexicontent');
 			if ($debug_mobile) {
-				$msg = "FC DEBUG_MOBILE: Detected resolution: " .$fc_screen_width."x".$fc_screen_height;
-				$app->enqueueMessage( $msg, 'message');
+				$msg = "FC DEBUG_MOBILE: Detected resolution: " . $fc_screen_width . "x" . $fc_screen_height;
+				$app->enqueueMessage($msg, 'message');
 			}
 			return;
 		}
 
 		// Calculate "low screen resolution" if needed
 
-		else if ( $session->has('screenSizeCookieTried', 'flexicontent') ) {
+		else if ($session->has('screenSizeCookieTried', 'flexicontent')) {
 			$session->set('fc_screen_resolution', false, 'flexicontent');
 			$session->set('fc_screen_width', 0, 'flexicontent');
 			$session->set('fc_screen_height', 0, 'flexicontent');
 			if ($debug_mobile) {
-				$app->enqueueMessage( "FC DEBUG_MOBILE: Detecting resolution failed, session variable 'fc_screen_resolution' was set to false", 'message');
+				$app->enqueueMessage("FC DEBUG_MOBILE: Detecting resolution failed, session variable 'fc_screen_resolution' was set to false", 'message');
 			}
 		}
 
@@ -1308,7 +1234,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		else {
 			if ($debug_mobile) {
-				$app->enqueueMessage( "FC DEBUG_MOBILE: Added JS code to detect and set screen resolution cookie", 'message');
+				$app->enqueueMessage("FC DEBUG_MOBILE: Added JS code to detect and set screen resolution cookie", 'message');
 			}
 			$this->setScreenSizeCookie();
 			$session->set('screenSizeCookieToBeAdded', 1, 'flexicontent');
@@ -1363,7 +1289,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			function fc_setCookie(cookieName, cookieValue, nDays, samesite="lax") {
 				var today = new Date();
 				var expire = new Date();
-				var path = "'.Uri::base(true).'";
+				var path = "' . Uri::base(true) . '";
 				if (nDays==null || nDays<0) nDays=0;
 				if (nDays) {
 					expire.setTime(today.getTime() + 3600000*24*nDays);
@@ -1382,8 +1308,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			' . /*($debug_mobile ? 'alert("Detected screen resolution: " + fc_screen_resolution + " this info will be used on next load");' : '') .*/ '
 			' . /*'window.location="'.$_SERVER["REQUEST_URI"].'"; ' .*/ '
 		';
-		if ($document && method_exists($document, 'addScriptDeclaration'))
-		{
+		if ($document && method_exists($document, 'addScriptDeclaration')) {
 			$document->addScriptDeclaration($js);
 		}
 		$screenSizeCookieAdded = true;
@@ -1404,18 +1329,18 @@ class plgSystemFlexisystem extends CMSPlugin
 		if (!$limit_checkout_hours && !$checkin_on_session_end) return true;
 
 		// Get last execution time from cache
-		$cache = Factory::getCache('plg_'.$this->_name.'_'.__FUNCTION__);
+		$cache = Factory::getCache('plg_' . $this->_name . '_' . __FUNCTION__);
 		$cache->setCaching(1);      // Force cache ON
 		$cache->setLifeTime(3600);  // Set expire time (default is 1 hour)
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 		// Execute every 15 minutes
 		$elapsed_time = time() - $last_check_time;  //Factory::getApplication()->enqueueMessage('plg_'.$this->_name.'::'.__FUNCTION__.'() elapsed_time: ' . $elapsed_time . '<br/>');
-		if ($elapsed_time < 15*60) return;  //Factory::getApplication()->enqueueMessage('EXECUTING: '.'plg_'.$this->_name.'::'.__FUNCTION__.'()<br/>');
+		if ($elapsed_time < 15 * 60) return;  //Factory::getApplication()->enqueueMessage('EXECUTING: '.'plg_'.$this->_name.'::'.__FUNCTION__.'()<br/>');
 
 		// Clear cache and call method again to restart the counter
-		$cache->clean('plg_'.$this->_name.'_'.__FUNCTION__);
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$cache->clean('plg_' . $this->_name . '_' . __FUNCTION__);
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 		$db  = Factory::getDbo();
 		$app = Factory::getApplication();
@@ -1430,8 +1355,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$current_time_secs = $date->toUnix();
 		//echo $date->toFormat()." <br>";
 
-		if ($checkin_on_session_end)
-		{
+		if ($checkin_on_session_end) {
 			$query = 'SELECT DISTINCT userid FROM #__session WHERE guest=0';
 			$db->setQuery($query);
 			$logged = $db->loadColumn();
@@ -1440,41 +1364,36 @@ class plgSystemFlexisystem extends CMSPlugin
 		// echo "Logged users:<br>"; print_r($logged); echo "<br><br>";
 
 		$tablenames = array('content', 'categories', 'modules', 'menu', 'flexicontent_files', 'flexicontent_fields', 'flexicontent_types');
-		foreach ( $tablenames as $tablename )
-		{
+		foreach ($tablenames as $tablename) {
 			//echo $tablename.":<br>";
 
 			// Get checked out records
-			$query = 'SELECT id, checked_out, checked_out_time FROM #__'.$tablename.' WHERE checked_out > 0';
+			$query = 'SELECT id, checked_out, checked_out_time FROM #__' . $tablename . ' WHERE checked_out > 0';
 			$db->setQuery($query);
 			$records = $db->loadObjectList();
 
-			if ( !count($records) ) continue;
+			if (!count($records)) continue;
 			$tz	= new DateTimeZone(Factory::getConfig()->get('offset'));
 
 			// Identify records that should be checked-in
 			$checkin_records = array();
-			foreach ($records as $record)
-			{
+			foreach ($records as $record) {
 				// Check user session ended
-				if ( $checkin_on_session_end && !isset($logged[$record->checked_out]) )
-				{
+				if ($checkin_on_session_end && !isset($logged[$record->checked_out])) {
 					//echo "USER session ended for: ".$record->checked_out." check-in record: ".$tablename.": ".$record->id."<br>";
 					$checkin_records[] = $record->id;
 					continue;
 				}
 
 				// Check maximum checkout time
-				if ( $limit_checkout_hours)
-				{
+				if ($limit_checkout_hours) {
 					$date = Factory::getDate($record->checked_out_time);
 					$date->setTimezone($tz);
 					$checkout_time_secs = $date->toUnix();
 					//echo $date->toFormat()." <br>";
 
 					$checkout_secs = $current_time_secs - $checkout_time_secs;
-					if ( $checkout_secs >= $max_checkout_secs )
-					{
+					if ($checkout_secs >= $max_checkout_secs) {
 						//echo "Check-in table record: ".$tablename.": ".$record->id.". Check-out time of ".$checkout_secs." secs exceeds maximum of ".$max_checkout_secs." secs, by user: ".$record->checked_out."<br>";
 						$checkin_records[] = $record->id;
 					}
@@ -1483,10 +1402,9 @@ class plgSystemFlexisystem extends CMSPlugin
 			$checkin_records = array_unique($checkin_records);
 
 			// Check-in the records
-			if ( count($checkin_records) )
-			{
+			if (count($checkin_records)) {
 				// NOTE in J4 the default is NULL ...
-				$query = 'UPDATE #__'.$tablename.' SET checked_out = 0 WHERE id IN ('.  implode(",", $checkin_records)  .')';
+				$query = 'UPDATE #__' . $tablename . ' SET checked_out = 0 WHERE id IN (' .  implode(",", $checkin_records)  . ')';
 				$db->setQuery($query);
 				$db->execute();
 			}
@@ -1507,18 +1425,18 @@ class plgSystemFlexisystem extends CMSPlugin
 		if (!$archive_on_publish_down) return true;
 
 		// Get last execution time from cache
-		$cache = Factory::getCache('plg_'.$this->_name.'_'.__FUNCTION__);
+		$cache = Factory::getCache('plg_' . $this->_name . '_' . __FUNCTION__);
 		$cache->setCaching(1);      // Force cache ON
 		$cache->setLifeTime(3600);  // Set expire time (default is 1 hour)
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 		// Execute every 15 minutes
 		$elapsed_time = time() - $last_check_time;  //Factory::getApplication()->enqueueMessage('plg_'.$this->_name.'::'.__FUNCTION__.'() elapsed_time: ' . $elapsed_time . '<br/>');
-		if ($elapsed_time < 15*60) return;  //Factory::getApplication()->enqueueMessage('EXECUTING: '.'plg_'.$this->_name.'::'.__FUNCTION__.'()<br/>');
+		if ($elapsed_time < 15 * 60) return;  //Factory::getApplication()->enqueueMessage('EXECUTING: '.'plg_'.$this->_name.'::'.__FUNCTION__.'()<br/>');
 
 		// Clear cache and call method again to restart the counter
-		$cache->clean('plg_'.$this->_name.'_'.__FUNCTION__);
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$cache->clean('plg_' . $this->_name . '_' . __FUNCTION__);
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 		$db  = Factory::getDbo();
 		$app = Factory::getApplication();
@@ -1531,21 +1449,21 @@ class plgSystemFlexisystem extends CMSPlugin
 		//echo $date->toFormat()." <br>";
 
 		$clear_publish_down_date = $this->params->get('clear_publish_down_date', 1);
-		$new_state = $archive_on_publish_down==1 ? 2 : 0;
+		$new_state = $archive_on_publish_down == 1 ? 2 : 0;
 
 		$_nowDate = 'UTC_TIMESTAMP()';
 		$nullDate	= $db->getNullDate();
 
-		$query = 'UPDATE #__content SET state = '.$new_state.
-			($clear_publish_down_date ? ', publish_down = '.$db->Quote($nullDate) : '').
-			' WHERE publish_down IS NOT NULL AND publish_down != '.$db->Quote($nullDate).' AND publish_down <= '.$_nowDate;
+		$query = 'UPDATE #__content SET state = ' . $new_state .
+			($clear_publish_down_date ? ', publish_down = ' . $db->Quote($nullDate) : '') .
+			' WHERE publish_down IS NOT NULL AND publish_down != ' . $db->Quote($nullDate) . ' AND publish_down <= ' . $_nowDate;
 		//echo $query;
 		$db->setQuery($query);
 		$db->execute();
 
-		$query = 'UPDATE #__flexicontent_items_tmp SET state = '.$new_state.
-			($clear_publish_down_date ? ', publish_down = '.$db->Quote($nullDate) : '').
-			' WHERE publish_down IS NOT NULL AND publish_down != '.$db->Quote($nullDate).' AND publish_down <= '.$_nowDate;
+		$query = 'UPDATE #__flexicontent_items_tmp SET state = ' . $new_state .
+			($clear_publish_down_date ? ', publish_down = ' . $db->Quote($nullDate) : '') .
+			' WHERE publish_down IS NOT NULL AND publish_down != ' . $db->Quote($nullDate) . ' AND publish_down <= ' . $_nowDate;
 		//echo $query;
 		$db->setQuery($query);
 		$db->execute();
@@ -1566,34 +1484,32 @@ class plgSystemFlexisystem extends CMSPlugin
 		$cparams = ComponentHelper::getParams('com_flexicontent');
 
 		// Get last execution time from cache
-		$cache = Factory::getCache('plg_'.$this->_name.'_'.__FUNCTION__);
+		$cache = Factory::getCache('plg_' . $this->_name . '_' . __FUNCTION__);
 		$cache->setCaching(1);      // Force cache ON
 		$cache->setLifeTime(3600);  // Set expire time (default is 1 hour)
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 		// Execute every 15 minutes
 		$elapsed_time = time() - $last_check_time;
 		//Factory::getApplication()->enqueueMessage('plg_'.$this->_name.'::'.__FUNCTION__.'() elapsed_time: ' . $elapsed_time . '<br/>');
 
-		if ($elapsed_time < 1*60) return;
+		if ($elapsed_time < 1 * 60) return;
 		//Factory::getApplication()->enqueueMessage('EXECUTING: '.'plg_'.$this->_name.'::'.__FUNCTION__.'()<br/>');
 
 		// Clear cache and call method again to restart the counter
-		$cache->clean('plg_'.$this->_name.'_'.__FUNCTION__);
-		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__) );
+		$cache->clean('plg_' . $this->_name . '_' . __FUNCTION__);
+		$last_check_time = $cache->get(array($this, '_getLastCheckTime'), array(__FUNCTION__));
 
 
 		// Try to allow using longer execution time and more memory
 		//$this->_setExecConfig();
 
 		$shell_exec_enabled = is_callable('shell_exec') && false === stripos(ini_get('disable_functions'), 'shell_exec');
-		if ($shell_exec_enabled)
-		{
+		if ($shell_exec_enabled) {
 			//echo $output = shell_exec('php ' . JPATH_ROOT . '/components/com_flexicontent/tasks/estorage.php > /dev/null 2>/dev/null &');
 			$output = shell_exec('php ' . JPATH_ROOT . '/components/com_flexicontent/tasks/estorage.php 2>&1');
 
-			if ($output)
-			{
+			if ($output) {
 				$log_filename = 'cron_estorage.php';
 				jimport('joomla.log.log');
 				Log::addLogger(
@@ -1617,60 +1533,49 @@ class plgSystemFlexisystem extends CMSPlugin
 		$option = $app->input->get('option', '', 'cmd');
 		$view   = $app->input->get('view', '', 'cmd');
 
-		if ($option==$this->extension && $view=='item')
-		{
+		if ($option == $this->extension && $view == 'item') {
 			$item_id = $app->input->get('id', 0, 'int');
-			if ( $item_id && $this->count_new_hit($item_id) )
-			{
+			if ($item_id && $this->count_new_hit($item_id)) {
 				$db = Factory::getDbo();
-				$db->setQuery('UPDATE #__content SET hits=hits+1 WHERE id = '.$item_id );
+				$db->setQuery('UPDATE #__content SET hits=hits+1 WHERE id = ' . $item_id);
 				$db->execute();
-				$db->setQuery('UPDATE #__flexicontent_items_tmp SET hits=hits+1 WHERE id = '.$item_id );
+				$db->setQuery('UPDATE #__flexicontent_items_tmp SET hits=hits+1 WHERE id = ' . $item_id);
 				$db->execute();
 			}
-		}
-
-		else if ($option=='com_content' && $view=='article')
-		{
+		} else if ($option == 'com_content' && $view == 'article') {
 			// Always increment if non FLEXIcontent view
 			$item_id = $app->input->get('id', 0, 'int');
-			if ( $item_id )
-			{
+			if ($item_id) {
 				$db = Factory::getDbo();
-				$db->setQuery('
+				$db->setQuery(
+					'
 					UPDATE #__flexicontent_items_tmp AS t
 					JOIN #__content AS i ON i.id=t.id
 					SET t.hits=i.hits
-					WHERE t.id = '.$item_id
+					WHERE t.id = ' . $item_id
 				);
 				$db->execute();
 			}
-		}
-
-		else if ($option==$this->extension &&  $view=='category')
-		{
+		} else if ($option == $this->extension &&  $view == 'category') {
 			$cat_id = $app->input->get('cid', 0, 'int');
 			$layout = $app->input->get('layout', '', 'cmd');
 
-			if ($cat_id && empty($layout))
-			{
+			if ($cat_id && empty($layout)) {
 				$hit_accounted = false;
 				$hit_arr = array();
 				$session = Factory::getSession();
 
-				if ($session->has('cats_hit', 'flexicontent'))
-				{
+				if ($session->has('cats_hit', 'flexicontent')) {
 					$hit_arr = $session->get('cats_hit', array(), 'flexicontent');
 					$hit_accounted = isset($hit_arr[$cat_id]);
 				}
 
 				// Add hit to session hit array
-				if (!$hit_accounted)
-				{
+				if (!$hit_accounted) {
 					$hit_arr[$cat_id] = $timestamp = time();  // Current time as seconds since Unix epoc;
 					$session->set('cats_hit', $hit_arr, 'flexicontent');
 					$db = Factory::getDbo();
-					$db->setQuery('UPDATE #__categories SET hits=hits+1 WHERE id = '.$cat_id );
+					$db->setQuery('UPDATE #__categories SET hits=hits+1 WHERE id = ' . $cat_id);
 					$db->execute();
 				}
 			}
@@ -1686,8 +1591,8 @@ class plgSystemFlexisystem extends CMSPlugin
 		$db = Factory::getDbo();
 		$visitorip = $_SERVER['REMOTE_ADDR'];  // Visitor IP
 		$current_secs = time();  // Current time as seconds since Unix epoch
-		if ($item_id==0) {
-			Factory::getApplication()->enqueueMessage(nl2br("Invalid item id or item id is not set in http request"),'error');
+		if ($item_id == 0) {
+			Factory::getApplication()->enqueueMessage(nl2br("Invalid item id or item id is not set in http request"), 'error');
 			return 1; // Invalid item id ?? (do not try to decrement hits in content table)
 		}
 
@@ -1695,16 +1600,14 @@ class plgSystemFlexisystem extends CMSPlugin
 		// CHECK RULE 1: Skip if visitor is from the specified ips
 		$hits_skip_ips = $this->cparams->get('hits_skip_ips', 1);   // Skip ips enabled
 		$hits_ips_list = $this->cparams->get('hits_ips_list', '127.0.0.1');  // List of ips, by default localhost
-		if($hits_skip_ips)
-		{
+		if ($hits_skip_ips) {
 			// consider as blocked ip , if remote address is not set (is this correct behavior?)
-			if( !isset($_SERVER['REMOTE_ADDR']) ) return 0;
+			if (!isset($_SERVER['REMOTE_ADDR'])) return 0;
 
 			$remoteaddr = $_SERVER['REMOTE_ADDR'];
 			$ips_array = explode(",", $hits_ips_list);
-			foreach($ips_array as $blockedip)
-			{
-				if (preg_match('/'.trim($blockedip).'/i', $remoteaddr)) return 0;  // found blocked ip, do not count new hit
+			foreach ($ips_array as $blockedip) {
+				if (preg_match('/' . trim($blockedip) . '/i', $remoteaddr)) return 0;  // found blocked ip, do not count new hit
 			}
 		}
 
@@ -1712,16 +1615,14 @@ class plgSystemFlexisystem extends CMSPlugin
 		// CHECK RULE 2: Skip if visitor is a bot
 		$hits_skip_bots = $this->cparams->get('hits_skip_bots', 1);  // Skip bots enabled
 		$hits_bots_list = $this->cparams->get('hits_bots_list', 'bot,spider,crawler,search,libwww,archive,slurp,teoma');   // List of bots
-		if($hits_skip_bots)
-		{
+		if ($hits_skip_bots) {
 			// consider as bot , if user agent name is not set (is this correct behavior?)
-			if( !isset($_SERVER['HTTP_USER_AGENT']) ) return 0;
+			if (!isset($_SERVER['HTTP_USER_AGENT'])) return 0;
 
 			$useragent = $_SERVER['HTTP_USER_AGENT'];
 			$bots_array = explode(",", $hits_bots_list);
-			foreach($bots_array as $botname)
-			{
-				if (preg_match('/'.trim($botname).'/i', $useragent)) return 0;  // found bot, do not count new hit
+			foreach ($bots_array as $botname) {
+				if (preg_match('/' . trim($botname) . '/i', $useragent)) return 0;  // found bot, do not count new hit
 			}
 		}
 
@@ -1741,21 +1642,17 @@ class plgSystemFlexisystem extends CMSPlugin
 				$session->set('hit', $hit_arr, 'flexicontent');
 				return 1;
 			}
-
 		} else {  // ALTERNATIVE METHOD (above is better, this will be removed?), by using db table to account hits, instead of user session
 
 			// CHECK RULE 3: minimum time to consider as unique visitor aka count hit
 			$secs_between_unique_hit = 60 * $this->cparams->get('hits_mins_to_unique', 10);  // Seconds between counting unique hits from an IP
 
 			// Try to find matching records for visitor's IP, that is within time limit of unique hit
-			$query = "SELECT COUNT(*) FROM #__flexicontent_hits_log WHERE ip=".$db->quote($visitorip)." AND (timestamp + ".$db->quote($secs_between_unique_hit).") > ".$db->quote($current_secs). " AND item_id=". $item_id;
+			$query = "SELECT COUNT(*) FROM #__flexicontent_hits_log WHERE ip=" . $db->quote($visitorip) . " AND (timestamp + " . $db->quote($secs_between_unique_hit) . ") > " . $db->quote($current_secs) . " AND item_id=" . $item_id;
 
-			try
-			{
+			try {
 				$result = $db->setQuery($query)->execute();
-			}
-			catch (Exception $e)
-			{
+			} catch (Exception $e) {
 				$query_create = "CREATE TABLE #__flexicontent_hits_log (item_id INT PRIMARY KEY, timestamp INT NOT NULL, ip VARCHAR(16) NOT NULL DEFAULT '0.0.0.0')";
 				$result = $db->setQuery($query_create)->execute();
 
@@ -1766,11 +1663,10 @@ class plgSystemFlexisystem extends CMSPlugin
 			$count = $db->loadResult();
 
 			// Log the visit into the hits logging db table
-			if (empty($count))
-			{
+			if (empty($count)) {
 				$query = "INSERT INTO #__flexicontent_hits_log (item_id, timestamp, ip) "
-					."  VALUES (".$db->quote($item_id).", ".$db->quote($current_secs).", ".$db->quote($visitorip).")"
-					." ON DUPLICATE KEY UPDATE timestamp=".$db->quote($current_secs).", ip=".$db->quote($visitorip);
+					. "  VALUES (" . $db->quote($item_id) . ", " . $db->quote($current_secs) . ", " . $db->quote($visitorip) . ")"
+					. " ON DUPLICATE KEY UPDATE timestamp=" . $db->quote($current_secs) . ", ip=" . $db->quote($visitorip);
 				$result = $db->setQuery($query)->execute();
 
 				// Last visit not found or is beyond time limit, count a new hit
@@ -1787,7 +1683,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	 * Function to restore serialized form data with:  JSON.stringify( jform.serializeArray() )
 	 * This is currently UNUSED, because we use an alternative without eval ...
 	 */
-	private function parse_json_decode_eval($string, & $count)
+	private function parse_json_decode_eval($string, &$count)
 	{
 		$parsed = array();    // Decompressed data to be returned
 
@@ -1795,8 +1691,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$count = count($pairs);
 		//echo "<pre>"; print_r($pairs); exit;
 
-		foreach ($pairs as $pair)
-		{
+		foreach ($pairs as $pair) {
 			$name = $pair['name'];
 			$value = $pair['value'];
 
@@ -1808,8 +1703,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			$value = '"' . str_replace('"', '\"', $value) . '"';
 
 			// CASE: name is an array,  some'var[index1][inde'x2]=value    -->   ][\'some\\\'var\'][\'index1\'][\'index2\']=\'value\';
-			if (strpos($name, '[') !== false)
-			{
+			if (strpos($name, '[') !== false) {
 				// we prepend an the 'result' array so replace first [ with ][
 				$name = preg_replace('|\[|', '][', $name, 1);
 				// Add double slashes to all multi-level index names of the array to handles slashes and Quote them thus treating indexes as strings
@@ -1836,7 +1730,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	/*
 	 * Function to restore serialized form data with:  JSON.stringify( jform.serializeArray() )
 	 */
-	private function parse_json_decode($string, & $count)
+	private function parse_json_decode($string, &$count)
 	{
 		$name_cnt = array();  // Empty index counters
 		$parsed = array();    // Decompressed data to be returned
@@ -1845,31 +1739,27 @@ class plgSystemFlexisystem extends CMSPlugin
 		$count = count($pairs);
 		//echo "<pre>"; print_r($pairs); echo "</pre>";
 
-		foreach ($pairs as $pair)
-		{
+		foreach ($pairs as $pair) {
 			$name = $pair['name'];
 			$value = $pair['value'];
 
 			$name_cnt[$name] = isset($name_cnt[$name]) ? $name_cnt[$name] + 1 : 0;
 			$indexes = preg_split('/[\[]+/', $name);
 
-			$point = & $parsed;
-			foreach($indexes as $n => &$index)
-			{
+			$point = &$parsed;
+			foreach ($indexes as $n => &$index) {
 				$index = trim($index, ']');
 				$index = $index === '' ? (string) $name_cnt[$name] : $index;
 
-				if ($n+1 == count($indexes))
-				{
+				if ($n + 1 == count($indexes)) {
 					break;
 				}
 
-				if ( !isset($point[$index]) || !is_array($point[$index]) )
-				{
+				if (!isset($point[$index]) || !is_array($point[$index])) {
 					$point[$index] = array();
 				}
 
-				$point = & $point[$index];
+				$point = &$point[$index];
 			}
 
 			// Assign value and ... !! UNSET ARRAY REFERENCE, BEWARE !!
@@ -1888,22 +1778,15 @@ class plgSystemFlexisystem extends CMSPlugin
 	{
 		$diff = array();
 
-		foreach ($arr1 as $i => $v)
-		{
-			if (array_key_exists($i, $arr2))
-			{
-				if (is_array($v))
-				{
+		foreach ($arr1 as $i => $v) {
+			if (array_key_exists($i, $arr2)) {
+				if (is_array($v)) {
 					$diff_rec = $this->array_diff_recursive($v, $arr2[$i]);
 					if (count($diff_rec)) $diff[$i] = $diff_rec;
-				}
-
-				else if ($v != $arr2[$i]) {
+				} else if ($v != $arr2[$i]) {
 					$diff[$i] = $v;
 				}
-			}
-
-			else {
+			} else {
 				$diff[$i] = $v;
 			}
 		}
@@ -1932,29 +1815,30 @@ class plgSystemFlexisystem extends CMSPlugin
 		$user = Factory::getUser();
 		$coreUserGroups = $user->getAuthorisedGroups();
 		// $coreViewLevels = $user->getAuthorisedViewLevels();
-		$aid = max ($user->getAuthorisedViewLevels());
+		$aid = max($user->getAuthorisedViewLevels());
 
 		$access = '';
 		if ($aid == 1)
 			$access = 'public'; // public
 		if ($aid == 2 || $aid > 3)
 			$access = 'registered'; // registered user or member of custom joomla group
-		if ($aid == 3
-			|| in_array($author_grp,$coreUserGroups)  	|| in_array($editor_grp,$coreUserGroups)
-			|| in_array($publisher_grp,$coreUserGroups)	|| in_array($manager_grp,$coreUserGroups)
-			|| max($coreUserGroups)>8
+		if (
+			$aid == 3
+			|| in_array($author_grp, $coreUserGroups)  	|| in_array($editor_grp, $coreUserGroups)
+			|| in_array($publisher_grp, $coreUserGroups)	|| in_array($manager_grp, $coreUserGroups)
+			|| max($coreUserGroups) > 8
 		)
 			$access = 'special'; // special user
-		if (in_array($admin_grp,$coreUserGroups))
+		if (in_array($admin_grp, $coreUserGroups))
 			$access = 'admin'; // is admin user
-		if (in_array($super_admin_grp,$coreUserGroups))
+		if (in_array($super_admin_grp, $coreUserGroups))
 			$access = 'superadmin'; // is super admin user
 
 		return $access;
 	}
 
 
-	function getCache($group='', $client=0)
+	function getCache($group = '', $client = 0)
 	{
 		$conf = Factory::getConfig();
 		//$client = 0;//0 is site, 1 is admin
@@ -1973,8 +1857,8 @@ class plgSystemFlexisystem extends CMSPlugin
 
 	private function _storeLessConf($table)
 	{
-		$xml_path  = \Joomla\CMS\Filesystem\Path::clean(JPATH_ADMINISTRATOR.'/components/com_flexicontent/config.xml');
-		$less_path = \Joomla\CMS\Filesystem\Path::clean(JPATH_ROOT.'/components/com_flexicontent/assets/less/include/mixins.less');
+		$xml_path  = \Joomla\CMS\Filesystem\Path::clean(JPATH_ADMINISTRATOR . '/components/com_flexicontent/config.xml');
+		$less_path = \Joomla\CMS\Filesystem\Path::clean(JPATH_ROOT . '/components/com_flexicontent/assets/less/include/mixins.less');
 
 
 		/**
@@ -1999,17 +1883,15 @@ class plgSystemFlexisystem extends CMSPlugin
 		$fieldSetNames = array('component');
 		$less_data = "/* This is created automatically, do NOT edit this manually! \nModify these in component configuration. */\n\n";
 
-		foreach($fieldSetNames as $fsname)
-		{
-			foreach($jform->getFieldset($fsname) as $field)
-			{
-				if ($field->getAttribute('cssprep')!='less') continue;  // Only add parameters meant to be less variables
+		foreach ($fieldSetNames as $fsname) {
+			foreach ($jform->getFieldset($fsname) as $field) {
+				if ($field->getAttribute('cssprep') != 'less') continue;  // Only add parameters meant to be less variables
 				$v = $table->params->get($field->fieldname);
 				if (is_array($v)) continue;  // array parameters not supported
 				$v = trim($v);
-				if ( !strlen($v) ) {
+				if (!strlen($v)) {
 					$v = $field->getAttribute('default');
-					if ( !strlen($v) ) continue;  // do not add empty parameters
+					if (!strlen($v)) continue;  // do not add empty parameters
 				}
 				$less_data .= '@' . $field->fieldname . ': ' . $v . ";\n";
 			}
@@ -2044,16 +1926,13 @@ class plgSystemFlexisystem extends CMSPlugin
 		 * Handle saving the parameters of 2 (1 frontend, 1 backend) item form default layouts
 		 */
 
-		if ($context === 'com_config.component' && $table->type === 'component' && $table->element === 'com_flexicontent')
-		{
-			if (Factory::getApplication()->isClient('administrator'))
-			{
+		if ($context === 'com_config.component' && $table->type === 'component' && $table->element === 'com_flexicontent') {
+			if (Factory::getApplication()->isClient('administrator')) {
 				$raw_data = Factory::getApplication()->input->post->get('jform', array(), 'array');
 
 				$table->params = new Registry($table->params);
 				$iflayout_params = !empty($raw_data['iflayout']) ? $raw_data['iflayout'] : array();
-				foreach($iflayout_params as $i => $v)
-				{
+				foreach ($iflayout_params as $i => $v) {
 					$table->params[$i] = $v;
 				}
 
@@ -2067,19 +1946,16 @@ class plgSystemFlexisystem extends CMSPlugin
 		 * Handle syncing permissions between com_content and com_flexicontent assets
 		 */
 
-		if ($context === 'com_config.component' && ($option === 'com_content' || $option === 'com_flexicontent'))
-		{
-			$rules_arr = @ $_POST['jform']['rules'];
+		if ($context === 'com_config.component' && ($option === 'com_content' || $option === 'com_flexicontent')) {
+			$rules_arr = @$_POST['jform']['rules'];
 			$option_other = $option == 'com_content'  ?  'com_flexicontent'  :  'com_content';
 
 			// Only save permissions rules, if user is allowed to edit them
 			// and if rules exists (in J3.5+ they are saved via AJAX thus code would normally be triggered only in J3.2 - J3.4)
-			if ( $rules_arr!= null && $user->authorise('core.admin', $option) )
-			{
+			if ($rules_arr != null && $user->authorise('core.admin', $option)) {
 				// Get asset of the other component
 				$asset = Table::getInstance('asset');
-				if (!$asset->loadByName($option_other))
-				{
+				if (!$asset->loadByName($option_other)) {
 					$root = Table::getInstance('asset');
 					$root->loadByName('root.1');
 					$asset->name = $option_other;
@@ -2091,32 +1967,26 @@ class plgSystemFlexisystem extends CMSPlugin
 				$asset_rules = json_decode($asset->rules, true);
 
 				// Copy rules, clearing empty ones
-				foreach($rules_arr as $rule_name => $rule_data)
-				{
-					if ( $option_other=='com_content' && substr($rule_name, 0, 5) != 'core.' )
-					{
+				foreach ($rules_arr as $rule_name => $rule_data) {
+					if ($option_other == 'com_content' && substr($rule_name, 0, 5) != 'core.') {
 						continue;
 					}
-					foreach($rule_data as $grp_id => $v)
-					{
-						if ( !strlen($v) ) unset($rules_arr[$rule_name][$grp_id]);
+					foreach ($rule_data as $grp_id => $v) {
+						if (!strlen($v)) unset($rules_arr[$rule_name][$grp_id]);
 					}
 					$asset_rules[$rule_name] = $rules_arr[$rule_name];
 				}
 
 				// If com_content configuration was saved then restore cleared *.own rules, and re-save com_content asset
-				if ($option == 'com_content')
-				{
+				if ($option == 'com_content') {
 					$com_content_asset = Table::getInstance('asset');
-					if ( $com_content_asset->loadByName('com_content') )
-					{
+					if ($com_content_asset->loadByName('com_content')) {
 						$com_content_rules = json_decode($com_content_asset->rules, true);
 						$com_content_rules['core.delete.own'] = isset($asset_rules['core.delete.own']) ? $asset_rules['core.delete.own'] : '';
 						$com_content_rules['core.edit.state.own'] = isset($asset_rules['core.edit.state.own']) ? $asset_rules['core.edit.state.own'] : '';
 						$rules = new Rules($com_content_rules);
 						$com_content_asset->rules = (string) $rules;
-						if (!$com_content_asset->check() || !$com_content_asset->store())
-						{
+						if (!$com_content_asset->check() || !$com_content_asset->store()) {
 							throw new RuntimeException($com_content_asset->getError());
 						}
 					}
@@ -2126,8 +1996,7 @@ class plgSystemFlexisystem extends CMSPlugin
 				$rules = new Rules($asset_rules);
 				$asset->rules = (string) $rules;
 
-				if (!$asset->check() || !$asset->store())
-				{
+				if (!$asset->check() || !$asset->store()) {
 					throw new RuntimeException($asset->getError());
 				}
 			}
@@ -2141,8 +2010,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		// ***
 
 		// Check for com_modules context
-		if ($context === 'com_modules.module' || $context === 'com_advancedmodules.module' || substr($context, 0, 10) === 'com_falang')
-		{
+		if ($context === 'com_modules.module' || $context === 'com_advancedmodules.module' || substr($context, 0, 10) === 'com_falang') {
 			// Check for non-empty layout parameter
 			$layout = $_POST['jform']['params']['layout'];
 			if (empty($layout)) return;
@@ -2154,21 +2022,19 @@ class plgSystemFlexisystem extends CMSPlugin
 			// Check if layout XML parameter file exists
 			$client = ApplicationHelper::getClientInfo($table->client_id);
 			$layoutpath = '';
-			if(count($layout_names)>1)
-				$layoutpath = Path::clean($client->path . '/templates/' . $layout_names[0] . '/html/' . $table->module .'/'.$layout_names[1].'.xml');
-			else if(count($layout_names)==1)
-				$layoutpath = Path::clean($client->path . '/modules/' . $table->module . '/tmpl/' . $layout .'.xml');
-			if (!$layoutpath || !file_exists($layoutpath))
-			{
+			if (count($layout_names) > 1)
+				$layoutpath = Path::clean($client->path . '/templates/' . $layout_names[0] . '/html/' . $table->module . '/' . $layout_names[1] . '.xml');
+			else if (count($layout_names) == 1)
+				$layoutpath = Path::clean($client->path . '/modules/' . $table->module . '/tmpl/' . $layout . '.xml');
+			if (!$layoutpath || !file_exists($layoutpath)) {
 				$layoutpath = Path::clean($client->path . '/modules/' . $table->module . '/tmpl/_fallback/_fallback.xml');
 				if (!file_exists($layoutpath)) return;
 			}
 
 			// Attempt to parse the XML file
 			$xml = simplexml_load_file($layoutpath);
-			if (!$xml)
-			{
-				Factory::getApplication()->enqueueMessage('Error parsing layout file of "'.$layoutpath.'". Layout parameters were not saved', 'warning');
+			if (!$xml) {
+				Factory::getApplication()->enqueueMessage('Error parsing layout file of "' . $layoutpath . '". Layout parameters were not saved', 'warning');
 				return;
 			}
 
@@ -2180,7 +2046,7 @@ class plgSystemFlexisystem extends CMSPlugin
 			// Set cleared layout parameters
 			$fset = 'params';
 			$layout_post = array();
-			$layout_post[$fset] = & $_POST['jform'][$fset];
+			$layout_post[$fset] = &$_POST['jform'][$fset];
 
 			//foreach ($jform->getGroup($fset) as $field) { if ( !empty($field->getAttribute('filter')) ) echo $field->fieldname . $field->getAttribute('filter') . "<br/>"; } exit;
 
@@ -2188,17 +2054,15 @@ class plgSystemFlexisystem extends CMSPlugin
 			$layout_post = $jform->filter($layout_post);   //echo "<pre>"; print_r($layout_post); echo "</pre>"; exit();
 			$isValid = $jform->validate($layout_post, $fset);
 
-			if (!$isValid)
-			{
+			if (!$isValid) {
 				Factory::getApplication()->enqueueMessage('Error validating layout posted parameters. Layout parameters were not saved', 'error');
 				return;
 			}
 
 			$params = new Registry($table->params);
-			foreach ($jform->getGroup($fset) as $field)
-			{
+			foreach ($jform->getGroup($fset) as $field) {
 				$fieldname = $field->fieldname;
-				if (substr($fieldname, 0, 2)=="__") continue;   // Skip field that start with __
+				if (substr($fieldname, 0, 2) == "__") continue;   // Skip field that start with __
 				$value = isset($layout_post[$fset][$fieldname]) ? $layout_post[$fset][$fieldname] : null;
 				$params->set($fieldname, $value);
 			}
@@ -2242,8 +2106,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	public function onContentPrepareForm($form, $data)
 	{
 		// Check we have a form.
-		if (!($form instanceof Form))
-		{
+		if (!($form instanceof Form)) {
 			$this->_subject->setError('JERROR_NOT_A_FORM');
 
 			return false;
@@ -2254,27 +2117,23 @@ class plgSystemFlexisystem extends CMSPlugin
 		$user       = Factory::getUser();
 
 		// Check we are loading the com_content article form
-		if ($form->getName() !== 'com_content.article' || Factory::getApplication()->input->get('option', '', 'CMD')!=='com_content')
-		{
+		if ($form->getName() !== 'com_content.article' || Factory::getApplication()->input->get('option', '', 'CMD') !== 'com_content') {
 			return true;
 		}
 
 		// Check for empty data, create empty object
-		if (!$data)
-		{
+		if (!$data) {
 			$data = new stdClass();
 			$data->id = 0;
 			$data->catid = 0;
 		}
 
 		// Check for array data, convert to object
-		if (is_array($data))
-		{
+		if (is_array($data)) {
 			$data = (object) $data;
 		}
 
-		if (Factory::getApplication()->input->getInt('a_id', 0))
-		{
+		if (Factory::getApplication()->input->getInt('a_id', 0)) {
 			$_id = Factory::getApplication()->input->getInt('a_id', 0);
 			$data->id = $_id;
 			Factory::getApplication()->input->set('id', $_id);
@@ -2291,8 +2150,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$default_type_id = $cparams->get('jarticle_form_typeid', 1);
 
 		// Get current type_id of the item
-		if ($data->id)
-		{
+		if ($data->id) {
 			$record = Table::getInstance($type = 'flexicontent_items', $prefix = '', $config = array());
 			$record->load($data->id);
 		}
@@ -2301,9 +2159,8 @@ class plgSystemFlexisystem extends CMSPlugin
 		// Get model and set default type if type not set already (new item or existing item with no type)
 		$model = new FlexicontentModelItem();
 
-		if (empty($data->type_id))
-		{
-			$types = flexicontent_html::getTypesList($type_ids=false, $check_perms = true, $published=true);
+		if (empty($data->type_id)) {
+			$types = flexicontent_html::getTypesList($type_ids = false, $check_perms = true, $published = true);
 			$default_type = isset($types[$default_type_id])
 				? $types[$default_type_id]
 				: reset($types);
@@ -2313,7 +2170,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// Get the item, clone it to avoid setting to it extra Registry / Array properties
 		// like fields, parameters that will slow down or cause recursion during (J)Form operations like bind
-		$fcform_item = clone($model->getItem($data->id, $check_view_access=false));
+		$fcform_item = clone($model->getItem($data->id, $check_view_access = false));
 
 		// Get the item's fields
 		$fcform_item->fields = $model->getExtrafields();
@@ -2330,19 +2187,19 @@ class plgSystemFlexisystem extends CMSPlugin
 		// ***
 
 		!Factory::getLanguage()->isRtl()
-			? $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_form.css', array('version' => FLEXI_VHASH))
-			: $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_form_rtl.css', array('version' => FLEXI_VHASH));
+			? $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_form.css', array('version' => FLEXI_VHASH))
+			: $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_form_rtl.css', array('version' => FLEXI_VHASH));
 
 		!Factory::getLanguage()->isRtl()
-			? $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_containers.css', array('version' => FLEXI_VHASH))
-			: $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_containers_rtl.css', array('version' => FLEXI_VHASH));
+			? $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_containers.css', array('version' => FLEXI_VHASH))
+			: $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_containers_rtl.css', array('version' => FLEXI_VHASH));
 
 		!Factory::getLanguage()->isRtl()
-			? $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_shared.css', array('version' => FLEXI_VHASH))
-			: $document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_shared_rtl.css', array('version' => FLEXI_VHASH));
+			? $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_shared.css', array('version' => FLEXI_VHASH))
+			: $document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_shared_rtl.css', array('version' => FLEXI_VHASH));
 
 		// Fields common CSS
-		$document->addStyleSheet(Uri::root(true).'/components/com_flexicontent/assets/css/flexi_form_fields.css', array('version' => FLEXI_VHASH));
+		$document->addStyleSheet(Uri::root(true) . '/components/com_flexicontent/assets/css/flexi_form_fields.css', array('version' => FLEXI_VHASH));
 
 
 		// ***
@@ -2358,11 +2215,11 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// Add js function to overload the joomla submitform validation
 		HTMLHelper::_('behavior.formvalidator');  // load default validation JS to make sure it is overriden
-		$document->addScript(Uri::root(true).'/components/com_flexicontent/assets/js/admin.js', array('version' => FLEXI_VHASH));
-		$document->addScript(Uri::root(true).'/components/com_flexicontent/assets/js/validate.js', array('version' => FLEXI_VHASH));
+		$document->addScript(Uri::root(true) . '/components/com_flexicontent/assets/js/admin.js', array('version' => FLEXI_VHASH));
+		$document->addScript(Uri::root(true) . '/components/com_flexicontent/assets/js/validate.js', array('version' => FLEXI_VHASH));
 
 		// Add js function for custom code used by FLEXIcontent item form
-		$document->addScript(Uri::root(true).'/components/com_flexicontent/assets/js/itemscreen.js', array('version' => FLEXI_VHASH));
+		$document->addScript(Uri::root(true) . '/components/com_flexicontent/assets/js/itemscreen.js', array('version' => FLEXI_VHASH));
 
 
 		// ***
@@ -2371,12 +2228,9 @@ class plgSystemFlexisystem extends CMSPlugin
 		// ***
 
 		$jcustom = $app->getUserState('com_flexicontent.edit.item.custom');
-		foreach ($fcform_item->fields as $field)
-		{
-			if (!$field->iscore)
-			{
-				if ( isset($jcustom[$field->name]) )
-				{
+		foreach ($fcform_item->fields as $field) {
+			if (!$field->iscore) {
+				if (isset($jcustom[$field->name])) {
 					$field->value = array();
 					foreach ($jcustom[$field->name] as $i => $_val)  $field->value[$i] = $_val;
 				}
@@ -2389,13 +2243,12 @@ class plgSystemFlexisystem extends CMSPlugin
 		// *** (b) Create the edit html of the CUSTOM fields by triggering 'onDisplayField'
 		// ***
 
-		foreach ($fcform_item->fields as $field)
-		{
+		foreach ($fcform_item->fields as $field) {
 			FlexicontentFields::getFieldFormDisplay($field, $fcform_item, $user);
 		}
 
 		// Set item for rendering flexicontent fields
-		require_once(Path::clean(JPATH_ROOT.'/administrator/components/com_flexicontent/models/fields/fcfieldwrapper.php'));
+		require_once(Path::clean(JPATH_ROOT . '/administrator/components/com_flexicontent/models/fields/fcfieldwrapper.php'));
 		\JFormFieldFCFieldWrapper::$fcform_item = $fcform_item;
 
 		// Get flexicontent fields
@@ -2404,10 +2257,10 @@ class plgSystemFlexisystem extends CMSPlugin
 				<fields name="attribs">
 					<fieldset
 						name="fcfields"
-						label="' . ( $fcform_item->typename
-				? Text::_('FLEXI_TYPE_NAME') . ' : ' . Text::_($fcform_item->typename)
-				: Text::_('FLEXI_TYPE_NOT_DEFINED')
-			) . '"
+						label="' . ($fcform_item->typename
+			? Text::_('FLEXI_TYPE_NAME') . ' : ' . Text::_($fcform_item->typename)
+			: Text::_('FLEXI_TYPE_NOT_DEFINED')
+		) . '"
 						description=""
 						addfieldpath="/administrator/components/com_flexicontent/models/fields"
 					>
@@ -2430,33 +2283,31 @@ class plgSystemFlexisystem extends CMSPlugin
 	}
 
 
-	function renderFields($context, &$row, &$params, $page=0, $eventName='')
+	function renderFields($context, &$row, &$params, $page = 0, $eventName = '')
 	{
 		// This is meant for Joomla article view
-		if ( $context!='com_content.article' ) return;
+		if ($context != 'com_content.article') return;
 
 		$app = Factory::getApplication();
 		if (
-			$app->input->get('option', '', 'CMD')!='com_content' ||
-			$app->input->get('view', '', 'CMD')!='article' ||
+			$app->input->get('option', '', 'CMD') != 'com_content' ||
+			$app->input->get('view', '', 'CMD') != 'article' ||
 			$app->input->get('isflexicontent', false, 'CMD')
 		) return;
 
 
 		static $fields_added = array();
 		static $items = array();
-		if (!empty($fields_added[$row->id]))
-		{
+		if (!empty($fields_added[$row->id])) {
 			return;
 		}
 
 
 		$this->_loadFcHelpersAndLanguage();
 
-		if (!isset($items[$row->id]))
-		{
+		if (!isset($items[$row->id])) {
 			$model = new FlexicontentModelItem();
-			$items[$row->id] = $model->getItem($row->id, $check_view_access=false);
+			$items[$row->id] = $model->getItem($row->id, $check_view_access = false);
 		}
 
 		// Get a copy of the item
@@ -2465,22 +2316,21 @@ class plgSystemFlexisystem extends CMSPlugin
 			: false;
 
 		// Item retrieval failed avoid fatal error
-		if (!$item)
-		{
+		if (!$item) {
 			return;
 		}
 
 
 		// Check placement and abort adding the fields
 		$placements_arr = array(
-			1=>'beforeContent',
-			2=>'afterContent'
+			1 => 'beforeContent',
+			2 => 'afterContent'
 		);
 		$allow_jview = $item->parameters->get('allow_jview', 0);
 		$placement = $item->parameters->get('jview_fields_placement', 1);
 
-		if ( $allow_jview != 1 || !$placement || !isset($placements_arr[$placement]) ) return;   //Disabled
-		if ( $placements_arr[$placement] != $eventName ) return;  // Not current event
+		if ($allow_jview != 1 || !$placement || !isset($placements_arr[$placement])) return;   //Disabled
+		if ($placements_arr[$placement] != $eventName) return;  // Not current event
 
 		$fields_added[$row->id] = true; // Only add once
 		$view = 'com_content.article' ? 'item' : 'category';
@@ -2488,8 +2338,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		// Only Render custom fields
 		$displayed_fields = array();
-		foreach ($item->fields as $field)
-		{
+		foreach ($item->fields as $field) {
 			// Prevent rendering of core fields
 			if ($field->iscore) continue;
 			// Prevent rendering of fields meant for form placement
@@ -2497,38 +2346,37 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			$displayed_fields[$field->name] = $field;
 			$values = isset($item->fieldvalues[$field->id]) ? $item->fieldvalues[$field->id] : array();
-			FlexicontentFields::renderField($item, $field, $values, $method='display', $view, false, $row);
+			FlexicontentFields::renderField($item, $field, $values, $method = 'display', $view, false, $row);
 		}
 
 		if (!count($displayed_fields)) return null;
 
 		// Render the list of groups
 		$field_html = array();
-		foreach($displayed_fields as $field_name => $field)
-		{
+		foreach ($displayed_fields as $field_name => $field) {
 			$_values = null;
-			if ( !isset($field->display) ) continue;
+			if (!isset($field->display)) continue;
 			$field_html[] = '
 				<div class="fc-field-box">
-					'.($field->parameters->get('display_label') ? '
-					<span class="flexi label">'.$field->label.'</span>' : '').'
-					<div class="flexi value">'.$field->display.'</div>
+					' . ($field->parameters->get('display_label') ? '
+					<span class="flexi label">' . $field->label . '</span>' : '') . '
+					<div class="flexi value">' . $field->display . '</div>
 				</div>
 				';
 		}
-		$_display = '<div class="fc-custom-fields-box">'.implode('', $field_html).'</div>';
+		$_display = '<div class="fc-custom-fields-box">' . implode('', $field_html) . '</div>';
 
 		return $_display;
 	}
 
 
 
-	function onContentBeforeDisplay($context, &$row, &$params, $page=0)
+	function onContentBeforeDisplay($context, &$row, &$params, $page = 0)
 	{
 		return $this->renderFields($context, $row, $params, $page, 'beforeContent');
 	}
 
-	function onContentAfterDisplay($context, &$row, &$params, $page=0)
+	function onContentAfterDisplay($context, &$row, &$params, $page = 0)
 	{
 		return $this->renderFields($context, $row, $params, $page, 'afterContent');
 	}
@@ -2538,7 +2386,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	// AFTER LOGIN
 	public function onUserAfterLogin($options)
 	{
-		require_once (JPATH_SITE.'/components/com_flexicontent/classes/flexicontent.helper.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/classes/flexicontent.helper.php');
 
 		$app  = Factory::getApplication();
 		$user = Factory::getUser();
@@ -2546,30 +2394,26 @@ class plgSystemFlexisystem extends CMSPlugin
 		$jcookie = $app->input->cookie;
 
 		// Set id for client-side (browser) caching via unique URLs (logged users)
-		$jcookie->set( 'fc_uid', UserHelper::getShortHashedUserAgent(), 0);
+		$jcookie->set('fc_uid', UserHelper::getShortHashedUserAgent(), 0);
 
 		// Add favourites via cookie to the DB
 		$fcfavs = flexicontent_favs::getInstance()->getRecords();
 
 		$types = array('item' => 0, 'category' => 1);
-		foreach($types as $type => $type_id)
-		{
+		foreach ($types as $type => $type_id) {
 			$favs = $fcfavs && isset($fcfavs->$type) ? $fcfavs->$type : array();
 
 			// Favourites via DB
 			$query 	= 'SELECT DISTINCT itemid, 1 AS fav'
 				. ' FROM #__flexicontent_favourites'
-				. ' WHERE type = ' . $type_id . ' AND userid = ' . ((int)$user->id)
-			;
+				. ' WHERE type = ' . $type_id . ' AND userid = ' . ((int)$user->id);
 			$db->setQuery($query);
 			$favoured = $db->loadObjectList('itemid');
 
 			// Collect ids favoured via Cookie but not already added as favoured via DB
 			$item_ids = array();
-			foreach($favs as $item_id)
-			{
-				if (!isset($favoured[$item_id]))
-				{
+			foreach ($favs as $item_id) {
+				if (!isset($favoured[$item_id])) {
 					$item_ids[] = $item_id;
 				}
 			}
@@ -2588,7 +2432,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	public function onUserAfterLogout($options)
 	{
 		$jcookie = Factory::getApplication()->input->cookie;
-		$jcookie->set( 'fc_uid', 'p', 0);
+		$jcookie->set('fc_uid', 'p', 0);
 	}
 
 
@@ -2605,8 +2449,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	 */
 	public function onContentChangeState($context, $pks, $value)
 	{
-		if ($context != 'com_content.article' || Factory::getApplication()->input->get('isflexicontent', false, 'CMD'))
-		{
+		if ($context != 'com_content.article' || Factory::getApplication()->input->get('isflexicontent', false, 'CMD')) {
 			return true;
 		}
 
@@ -2627,10 +2470,10 @@ class plgSystemFlexisystem extends CMSPlugin
 		$itemmodel = new FlexicontentModelItem();
 
 		// Get item setting it into the model (ITEM DATE: _id, _type_id, _params, etc will be updated)
-		$item = $itemmodel->getItem($cid, $check_view_access=false, $no_cache=true);
+		$item = $itemmodel->getItem($cid, $check_view_access = false, $no_cache = true);
 
 		// Load backend 'flexicontent' items model and use it to update flexicontent temporary data
-		JLoader::register('FlexicontentModelItems', JPATH_ADMINISTRATOR.'/components/com_flexicontent/models/items.php');
+		JLoader::register('FlexicontentModelItems', JPATH_ADMINISTRATOR . '/components/com_flexicontent/models/items.php');
 		$items_model = new FlexicontentModelItems();
 		$items_model->updateItemCountingData(array($item));
 
@@ -2653,28 +2496,22 @@ class plgSystemFlexisystem extends CMSPlugin
 	public function onContentBeforeSave($context, $item, $isNew, $data = array())
 	{
 		// Workaround for wrong event triggering bug in Advanced module manager 7.x (up to at least version 7.9.2)
-		if ($context === 'com_advancedmodules.module')
-		{
+		if ($context === 'com_advancedmodules.module') {
 			return $this->onExtensionBeforeSave($context, $item, $isNew);
 		}
 
-		if (($context !== 'com_content.article' && $context !== 'com_content.form') || Factory::getApplication()->input->get('isflexicontent', false, 'CMD'))
-		{
+		if (($context !== 'com_content.article' && $context !== 'com_content.form') || Factory::getApplication()->input->get('isflexicontent', false, 'CMD')) {
 			return true;
 		}
 
-		if (Factory::getApplication()->input->getInt('a_id', 0))
-		{
+		if (Factory::getApplication()->input->getInt('a_id', 0)) {
 			$_id = Factory::getApplication()->input->getInt('a_id', 0);
 			Factory::getApplication()->input->set('id', $_id);
 			$item->id = $_id;
 
-			if (is_object($data))
-			{
+			if (is_object($data)) {
 				$data->id = $_id;
-			}
-			elseif (is_array($data))
-			{
+			} elseif (is_array($data)) {
 				$data['id'] = $_id;
 			}
 		}
@@ -2699,8 +2536,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$model->mergeAttributes($record, $data, $mergeProperties, $mergeOptions);
 
 		$item_data = array();
-		foreach($mergeProperties as $prop)
-		{
+		foreach ($mergeProperties as $prop) {
 			$item_data[$prop] = isset($record->$prop) ? $record->$prop : null;
 		}
 		Factory::getSession()->set('flexicontent.item.data', $item_data, 'flexicontent');
@@ -2721,8 +2557,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		if (!isset($item->id)) return;
 
 		//Factory::getApplication()->enqueueMessage("context: $context");
-		if ($depth === 0)
-		{
+		if ($depth === 0) {
 			// First delete existing usage
 			$query = $db->getQuery(true)
 				->delete($db->qn('#__flexicontent_file_usage'))
@@ -2732,25 +2567,20 @@ class plgSystemFlexisystem extends CMSPlugin
 			//Factory::getApplication()->enqueueMessage($query);
 		}
 
-		if ($propValues) foreach($propValues as $prop => $value)
-		{
+		if ($propValues) foreach ($propValues as $prop => $value) {
 			// Do not know how to handle / cannot handle these cases
-			if (!isset($item->id) || !is_string($prop))
-			{
+			if (!isset($item->id) || !is_string($prop)) {
 				continue;
 			}
 			//Factory::getApplication()->enqueueMessage($path . $prop . '<br>');
 
 			// Do not search text property, instead we will search text and introtext
-			if ($context === 'com_content.article' && $prop === 'text')
-			{
+			if ($context === 'com_content.article' && $prop === 'text') {
 				continue;
 			}
 
-			if (!is_string($value))
-			{
-				if (is_array($value) && $depth <= 3)
-				{
+			if (!is_string($value)) {
+				if (is_array($value) && $depth <= 3) {
 					$this->_updateFileUsage_FcFileBtn_DownloadLinks($context, $item, $isNew, $value, $path . $prop . '.', $depth + 1);
 				}
 				continue;
@@ -2758,22 +2588,19 @@ class plgSystemFlexisystem extends CMSPlugin
 
 			$matches = array();
 			$regexp_PHP_NONSEF = "[ \t\n\r]+href=\"((http:\/\/|https:\/\/)?([^\"]*)index.php\?([^\"]*))\"";
-			preg_match_all('/'. $regexp_PHP_NONSEF . '/', $value, $matches);
+			preg_match_all('/' . $regexp_PHP_NONSEF . '/', $value, $matches);
 
 			$cnt = $matches ? count($matches[0]) : 0;
-			if ($cnt)
-			{
+			if ($cnt) {
 				//Factory::getApplication()->enqueueMessage('<pre>'.htmlspecialchars(print_r($matches, true), ENT_COMPAT, 'UTF-8').'</pre>');
 
-				for ($i=0; $i<$cnt; $i++)
-				{
+				for ($i = 0; $i < $cnt; $i++) {
 					parse_str(html_entity_decode($matches[4][$i]), $vars);
 
 					if (
 						!empty($vars['option']) && !empty($vars['task']) && !empty($vars['id']) &&
 						$vars['option'] === 'com_flexicontent' && $vars['task'] === 'download_file'
-					)
-					{
+					) {
 						//Factory::getApplication()->enqueueMessage('FOUND');
 						$query = $db->getQuery(true)
 							->insert($db->qn('#__flexicontent_file_usage'))
@@ -2785,16 +2612,14 @@ class plgSystemFlexisystem extends CMSPlugin
 							))
 							->values(
 								$db->q($item->id) . ', ' .
-								$db->q($context) . ', ' .
-								$db->q($vars['id']) . ', ' .
-								$db->q($path . $prop)
+									$db->q($context) . ', ' .
+									$db->q($vars['id']) . ', ' .
+									$db->q($path . $prop)
 							);
 
 						try {
 							$db->setQuery($query)->execute();
-						}
-						catch (Exception $e)
-						{
+						} catch (Exception $e) {
 							continue;
 						}
 					}
@@ -2820,8 +2645,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
 		// Workaround for wrong event triggering bug in Advanced module manager 7.x (up to at least version 7.9.2)
-		if ($context === 'com_advancedmodules.module')
-		{
+		if ($context === 'com_advancedmodules.module') {
 			return $this->onExtensionAfterSave($context, $item, $isNew);
 		}
 
@@ -2831,8 +2655,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		 */
 		$this->_updateFileUsage_FcFileBtn_DownloadLinks($context, $item, $isNew, $data);
 
-		if (($context !== 'com_content.article' && $context !== 'com_content.form') || Factory::getApplication()->input->get('isflexicontent', false, 'CMD'))
-		{
+		if (($context !== 'com_content.article' && $context !== 'com_content.form') || Factory::getApplication()->input->get('isflexicontent', false, 'CMD')) {
 			return true;
 		}
 
@@ -2851,7 +2674,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$data['vstate'] = 2;
 
 		// RAW (flexicontent) Custom fields data, validation will be done by each field
-		$data['custom']= $app->input->post->get('custom', array(), 'array');
+		$data['custom'] = $app->input->post->get('custom', array(), 'array');
 
 
 		// ***
@@ -2862,8 +2685,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		$default_type_id = $cparams->get('jarticle_form_typeid', 1);
 
 		// Get current type_id of the item
-		if (!$isNew)
-		{
+		if (!$isNew) {
 			$record = Table::getInstance($type = 'flexicontent_items', $prefix = '', $config = array());
 			$record->load($data['id']);
 			$data['type_id'] = $record->type_id;
@@ -2872,9 +2694,8 @@ class plgSystemFlexisystem extends CMSPlugin
 		// Get model and set default type if type not set already (new item or existing item with no type)
 		$model = new FlexicontentModelItem();
 
-		if (empty($data['type_id']))
-		{
-			$types = flexicontent_html::getTypesList($type_ids=false, $check_perms = true, $published=true);
+		if (empty($data['type_id'])) {
+			$types = flexicontent_html::getTypesList($type_ids = false, $check_perms = true, $published = true);
 			$default_type = isset($types[$default_type_id])
 				? $types[$default_type_id]
 				: reset($types);
@@ -2903,7 +2724,7 @@ class plgSystemFlexisystem extends CMSPlugin
 		//*** Call backend 'flexicontent' items model to update flexicontent temporary data
 		//***
 
-		JLoader::register('FlexicontentModelItems', JPATH_ADMINISTRATOR.'/components/com_flexicontent/models/items.php');
+		JLoader::register('FlexicontentModelItems', JPATH_ADMINISTRATOR . '/components/com_flexicontent/models/items.php');
 		$items_model = new FlexicontentModelItems();
 		$items_model->updateItemCountingData(false, $item->catid);
 
@@ -2914,8 +2735,7 @@ class plgSystemFlexisystem extends CMSPlugin
 
 		$item_params = Factory::getSession()->get('flexicontent.item.data', null, 'flexicontent');
 
-		if ($item_params)
-		{
+		if ($item_params) {
 			$record = Table::getInstance($type = 'flexicontent_items', $prefix = '', $config = array());
 			$record->load($item->id);
 			$record->bind($item_params);
@@ -2940,15 +2760,15 @@ class plgSystemFlexisystem extends CMSPlugin
 	private function _loadFcHelpersAndLanguage()
 	{
 		Factory::getLanguage()->load('com_flexicontent', JPATH_ADMINISTRATOR);
-		Table::addIncludePath(JPATH_ADMINISTRATOR.'/components/com_flexicontent/tables');
+		Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_flexicontent/tables');
 
-		require_once (JPATH_ADMINISTRATOR.'/components/com_flexicontent/defineconstants.php');
-		require_once (JPATH_SITE.'/components/com_flexicontent/classes/flexicontent.fields.php');
-		require_once (JPATH_SITE.'/components/com_flexicontent/classes/flexicontent.helper.php');
-		require_once (JPATH_SITE.'/components/com_flexicontent/classes/flexicontent.categories.php');
-		require_once (JPATH_SITE.'/components/com_flexicontent/helpers/permission.php');
+		require_once(JPATH_ADMINISTRATOR . '/components/com_flexicontent/defineconstants.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/classes/flexicontent.fields.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/classes/flexicontent.helper.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/classes/flexicontent.categories.php');
+		require_once(JPATH_SITE . '/components/com_flexicontent/helpers/permission.php');
 
-		JLoader::register('FlexicontentModelItem', JPATH_BASE.'/components/com_flexicontent/models/item.php');
+		JLoader::register('FlexicontentModelItem', JPATH_BASE . '/components/com_flexicontent/models/item.php');
 	}
 
 
@@ -2956,19 +2776,16 @@ class plgSystemFlexisystem extends CMSPlugin
 	{
 		$db = Factory::getDbo();
 
-		if (!is_array($item_ids))
-		{
+		if (!is_array($item_ids)) {
 			$obj = new stdClass();
 			$obj->itemid = (int)$item_ids;
 			$obj->userid = (int)$user_id;
 			$obj->type   = (int)$type;
 
 			return $db->insertObject('#__flexicontent_favourites', $obj);
-		}
-		elseif (!empty($item_ids))
-		{
+		} elseif (!empty($item_ids)) {
 			$vals = array();
-			foreach($item_ids as $item_id) $vals[]= ''
+			foreach ($item_ids as $item_id) $vals[] = ''
 				. '('
 				. ((int)$item_id)  . ', '
 				. ((int)$user_id)  . ', '
@@ -2986,8 +2803,7 @@ class plgSystemFlexisystem extends CMSPlugin
 	{
 		$handled_types = array('file', 'weblink');
 
-		if (!in_array($field->field_type, $handled_types))
-		{
+		if (!in_array($field->field_type, $handled_types)) {
 			return;
 		}
 
@@ -3006,36 +2822,48 @@ class plgSystemFlexisystem extends CMSPlugin
 	{
 		// Display fatal errors, warnings, notices
 		error_reporting(E_ERROR || E_WARNING || E_NOTICE);
-		ini_set('display_errors',1);
+		ini_set('display_errors', 1);
 
 		// Try to increment some limits
-		@ set_time_limit( 3600 );   // try to set execution time 60 minutes
-		ignore_user_abort( true ); // continue execution if client disconnects
+		@set_time_limit(3600);   // try to set execution time 60 minutes
+		ignore_user_abort(true); // continue execution if client disconnects
 
 		// Try to increment memory limits
-		$memory_limit	= trim( @ ini_get( 'memory_limit' ) );
-		if ( $memory_limit )
-		{
-			switch (strtolower(substr($memory_limit, -1)))
-			{
-				case 'm': $memory_limit = (int)substr($memory_limit, 0, -1) * 1048576; break;
-				case 'k': $memory_limit = (int)substr($memory_limit, 0, -1) * 1024; break;
-				case 'g': $memory_limit = (int)substr($memory_limit, 0, -1) * 1073741824; break;
+		$memory_limit	= trim(@ini_get('memory_limit'));
+		if ($memory_limit) {
+			switch (strtolower(substr($memory_limit, -1))) {
+				case 'm':
+					$memory_limit = (int)substr($memory_limit, 0, -1) * 1048576;
+					break;
+				case 'k':
+					$memory_limit = (int)substr($memory_limit, 0, -1) * 1024;
+					break;
+				case 'g':
+					$memory_limit = (int)substr($memory_limit, 0, -1) * 1073741824;
+					break;
 				case 'b':
-					switch (strtolower(substr($memory_limit, -2, 1)))
-					{
-						case 'm': $memory_limit = (int)substr($memory_limit, 0, -2) * 1048576; break;
-						case 'k': $memory_limit = (int)substr($memory_limit, 0, -2) * 1024; break;
-						case 'g': $memory_limit = (int)substr($memory_limit, 0, -2) * 1073741824; break;
-						default : break;
-					} break;
-				default: break;
+					switch (strtolower(substr($memory_limit, -2, 1))) {
+						case 'm':
+							$memory_limit = (int)substr($memory_limit, 0, -2) * 1048576;
+							break;
+						case 'k':
+							$memory_limit = (int)substr($memory_limit, 0, -2) * 1024;
+							break;
+						case 'g':
+							$memory_limit = (int)substr($memory_limit, 0, -2) * 1073741824;
+							break;
+						default:
+							break;
+					}
+					break;
+				default:
+					break;
 			}
-			if ( $memory_limit < 16 * 1024 * 1024 ) @ ini_set( 'memory_limit', '16M' );
-			if ( $memory_limit < 32 * 1024 * 1024 ) @ ini_set( 'memory_limit', '32M' );
-			if ( $memory_limit < 64 * 1024 * 1024 ) @ ini_set( 'memory_limit', '64M' );
-			if ( $memory_limit < 128 * 1024 * 1024 ) @ ini_set( 'memory_limit', '128M' );
-			if ( $memory_limit < 256 * 1024 * 1024 ) @ ini_set( 'memory_limit', '256M' );
+			if ($memory_limit < 16 * 1024 * 1024) @ini_set('memory_limit', '16M');
+			if ($memory_limit < 32 * 1024 * 1024) @ini_set('memory_limit', '32M');
+			if ($memory_limit < 64 * 1024 * 1024) @ini_set('memory_limit', '64M');
+			if ($memory_limit < 128 * 1024 * 1024) @ini_set('memory_limit', '128M');
+			if ($memory_limit < 256 * 1024 * 1024) @ini_set('memory_limit', '256M');
 		}
 	}
 }

--- a/plugins/system/flexisystem/flexisystem.php
+++ b/plugins/system/flexisystem/flexisystem.php
@@ -346,6 +346,7 @@ class plgSystemFlexisystem extends CMSPlugin
 				$suhosin_lim = ini_get('suhosin.request.max_vars');
 				if ($suhosin_lim < $max_input_vars) $max_input_vars = $suhosin_lim;
 			}
+			HTMLHelper::_('jquery.framework');
 			$js .= "
 				jQuery(document).ready(function() {
 					Joomla.fc_max_input_vars = ".$max_input_vars.";
@@ -361,7 +362,8 @@ class plgSystemFlexisystem extends CMSPlugin
 			$isAdmin && (
 			($option=='com_users' && ($view == 'user'))
 			)
-		)
+		) {
+			HTMLHelper::_('jquery.framework');
 			$js .= "
 				jQuery(document).ready(function() {
 					var el = parent.document.getElementById('fc_modal_popup_container');
@@ -371,6 +373,7 @@ class plgSystemFlexisystem extends CMSPlugin
 					}
 				});
 			";
+		}
 		if ($js) $document->addScriptDeclaration($js);
 
 
@@ -1970,8 +1973,8 @@ class plgSystemFlexisystem extends CMSPlugin
 
 	private function _storeLessConf($table)
 	{
-		$xml_path  = \Joomla\Filesystem\Path::clean(JPATH_ADMINISTRATOR.'/components/com_flexicontent/config.xml');
-		$less_path = \Joomla\Filesystem\Path::clean(JPATH_ROOT.'/components/com_flexicontent/assets/less/include/mixins.less');
+		$xml_path  = \Joomla\CMS\Filesystem\Path::clean(JPATH_ADMINISTRATOR.'/components/com_flexicontent/config.xml');
+		$less_path = \Joomla\CMS\Filesystem\Path::clean(JPATH_ROOT.'/components/com_flexicontent/assets/less/include/mixins.less');
 
 
 		/**


### PR DESCRIPTION

HTMLHelper::_('jquery.framework') isn't compatible with j6.

IF you still require old FLEXIContent compatibility then insert this code:

if (FLEXI_J40GE) {
	$wa = Factory::getApplication()
		->getDocument()
		->getWebAssetManager();

	$wa->useScript('jquery');
	$wa->useScript('jquery-noconflict');
} else {
	HTMLHelper::_('jquery.framework');
}