### PR TITLE
Category handling

### DIFF
--- a/admin/views/item/view.html.php
+++ b/admin/views/item/view.html.php
@@ -14,7 +14,6 @@ defined('_JEXEC') or die('Restricted access');
 use Joomla\CMS\Language\Text;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
-use Joomla\CMS\Component\ComponentHelper;
 
 JLoader::register('FlexicontentViewBaseRecord', JPATH_ADMINISTRATOR . '/components/com_flexicontent/helpers/base/view_record.php');
 
@@ -92,7 +91,7 @@ class FlexicontentViewItem extends FlexicontentViewBaseRecord
 
 		$app        = \Joomla\CMS\Factory::getApplication();
 		$jinput     = $app->input;
-		$dispatcher = $app->getDispatcher();
+		$dispatcher = JEventDispatcher::getInstance();
 		$document   = \Joomla\CMS\Factory::getDocument();
 		$config     = \Joomla\CMS\Factory::getConfig();
 		$session    = \Joomla\CMS\Factory::getSession();
@@ -1036,10 +1035,18 @@ class FlexicontentViewItem extends FlexicontentViewBaseRecord
 
 		if ($isnew)
 		{
+			$request_maincat = $jinput->get('maincat', 0, 'int');
+			$request_catid   = $jinput->get('catid', 0, 'int');
+			$request_cats    = $jinput->get('cats', array(), 'array');
+
+			$request_cats = is_array($request_cats) ? $request_cats : array($request_cats);
+			$request_cats = ArrayHelper::toInteger($request_cats);
+			$request_cats = array_values(array_filter(array_unique($request_cats)));
+
 			// Case for preselected main category for new items
 			$maincat = $item->catid
 				? $item->catid
-				: $jinput->get('maincat', 0, 'int');
+				: $request_maincat;
 
 			// For backend form also try the items manager 's category filter
 			if ( $app->isClient('administrator') && !$maincat )
@@ -1056,11 +1063,15 @@ class FlexicontentViewItem extends FlexicontentViewBaseRecord
 				$item->categories = array();
 			}
 
-			if ( $page_params->get('cid_default') )
+			if ($request_cats)
+			{
+				$item->categories = array_values(array_unique(array_merge($item->categories, $request_cats)));
+			}
+			elseif ( $page_params->get('cid_default') )
 			{
 				$item->categories = $page_params->get('cid_default');
 			}
-			if ( $page_params->get('catid_default') )
+			if ( !$request_catid && !$request_maincat && $page_params->get('catid_default') )
 			{
 				$item->catid = $page_params->get('catid_default');
 			}
@@ -2058,7 +2069,7 @@ class FlexicontentViewItem extends FlexicontentViewBaseRecord
 		$app    = \Joomla\CMS\Factory::getApplication();
 		$jinput = $app->input;
 
-		$dispatcher = $app->getDispatcher();
+		$dispatcher = JEventDispatcher::getInstance();
 		$session  = \Joomla\CMS\Factory::getSession();
 		$document = \Joomla\CMS\Factory::getDocument();
 		$menus = $app->getMenu();


### PR DESCRIPTION
## Allow secondary categories to be set from the administrator URL when adding new items

This PR allows the FLEXIContent admin to add Item URLs to preselect one or more secondary categories using repeated `cats[]` URL parameters.


Example URL:

```
index.php?option=com_flexicontent&controller=items&task=items.add&typeid=14&maincat=80&cats[]=71&cats[]=17
```

URL - sets maincategory to 80 and 2 secondary categories:

```
maincat=80&cats[]=71&cats[]=17
```


<img width="2145" height="703" alt="image" src="https://github.com/user-attachments/assets/25be03df-6248-420a-9b52-33ab0e0861dd" />

### 
Why this is useful

When creating long administrator URLs or custom admin shortcut buttons, we often need to open the FLEXIContent Add Item form with the correct category assignments already selected.

Before this change, the URL could reliably set the main category with maincat, but secondary category support from the URL was missing or inconsistent.

This makes add-item URLs more useful for admin workflows where products/items need to be created directly into a known main category and also assigned to one or more secondary categories.





