### PR TITLE
Hide DB-backed columns in folder mode

### DIFF
--- a/admin/views/fileselement/view.html.php
+++ b/admin/views/fileselement/view.html.php
@@ -175,6 +175,17 @@ class FlexicontentViewFileselement extends FlexicontentViewBaseRecords
 
 			unset($cols['_SAVED_']);
 		}
+
+		// Folder-mode rows come from the filesystem, not #__flexicontent_files.
+		// Hide DB-backed columns so the shared filemanager template does not
+		// render controls for properties that do not exist on these rows.
+		if ($folder_mode)
+		{
+			foreach(array('state', 'access', 'lang', 'hits', 'target', 'stamp', 'usage', 'uploader', 'file_id') as $col)
+			{
+				unset($cols[$col]);
+			}
+		}
 		
 		/*
 		 * Column selection of optional columns not given)


### PR DESCRIPTION
Added logic to hide DB-backed columns in folder mode.

**PROBLEM**
The image selector popup is `com_flexicontent` `view=fileselement&layout=image`, even though it is opened from the item edit form. The `fileselement` image layout reuses the filemanager default template.

For image fields using folder mode (`image_source=1`), rows are built by `getFilesFromPath()`. These rows are filesystem-only objects, so they have `filename`, `size`, `uploaded`, `icon`, etc., but not DB-backed file properties like `access`, `access_level`, `published`, `hits`, or real file IDs.

The `fileselement` view still enables `access` by default via:

```php
$filelist_cols = $filelist_cols ?: array('upload_time', 'access', 'size');
```


Then the shared filemanager template renders the access column and calls:

```
flexicontent_html::userlevel('access['.$row->id.']', $row->access, ...)
```

That causes the undefined `$row->access warning` and the downstream Joomla Select.php deprecation from receiving null.

**Fix:**

After building $cols, folder mode now removes DB-backed columns before the shared template renders:

```
if ($folder_mode)
{
	foreach(array('state', 'access', 'lang', 'hits', 'target', 'stamp', 'usage', 'uploader', 'file_id') as $col)
	{
		unset($cols[$col]);
	}
}
```
This is better than adding fake access values to folder rows, because folder-mode row IDs are synthetic list counters, not real #__flexicontent_files IDs. Showing the access dropdown would submit invalid IDs to filemanager.access.


<img width="759" height="536" alt="image" src="https://github.com/user-attachments/assets/c685117b-54bc-4310-b832-923dd70eb292" />
