### PR TITLE
An issue with raw links to FlexiContent content in the JCE editor has…

### DIFF
--- a/admin/views/itemelement/tmpl/default.php
+++ b/admin/views/itemelement/tmpl/default.php
@@ -557,11 +557,15 @@ if ($js)
 
 					<?php if ($isXtdBtn): ?>
 
-						<?php $attribs = 'data-function="' . $this->escape($onclick) . '"'
+						<?php
+							$item_slug = strlen($row->alias) ? $row->id . ':' . $row->alias : $row->id;
+							$cat_slug  = isset($globalcats[$row->catid]) ? $globalcats[$row->catid]->slug : $row->catid;
+
+							$attribs = 'data-function="' . $this->escape($onclick) . '"'
 							. ' data-id="' . $this->escape($row->id) . '"'
 							. ' data-title="' . $this->escape($row->title) . '"'
 							. ' data-cat-id="' . $this->escape($row->catid) . '"'
-							. ' data-uri="' . $this->escape(FlexicontentHelperRoute::getItemRoute($row->id, $row->catid, $_Itemid = 0, $row)) . '"'
+							. ' data-uri="' . $this->escape(FlexicontentHelperRoute::getItemRoute($item_slug, $cat_slug, $_Itemid = 0, $row)) . '"'
 							. ' data-language="' . $this->escape($row->language) . '"';
 						?>
 					<span class="<?php echo $this->tooltip_class; ?>" title="<?php echo HTMLHelper::tooltipText(Text::_('FLEXI_SELECT'), $row->title . '<br/><br/>' . $pcpath, 0, 1); ?>">

--- a/site/librairies/JCE/links/flexicontentlinks/items.php
+++ b/site/librairies/JCE/links/flexicontentlinks/items.php
@@ -133,7 +133,7 @@ class FlexicontentlinksItems extends \Joomla\CMS\Object\CMSObject {
 		{
 			$url = FlexicontentHelperRoute::getItemRoute($content->slug, $content->catslug, 0, $content);
 			$items[] = array(
-				'id'	=>  'index.php?option=com_flexicontent&view=item&cid='.$content->catid.'&id='.$content->id,
+				'id'	=>  'index.php?option=com_flexicontent&view=item&cid='.$content->catslug.'&id='.$content->slug,
 				'url'	=>	self::route($url),
 				'name'	=>	$content->ititle.'(id='.$content->id.')',
 				'class'	=>	'file flexiitem'


### PR DESCRIPTION
An issue with raw links to FlexiContent content in the JCE editor has been fixed.
FlexiContent generated links without aliases.
Example: index.php?option=com_flexicontent&view=item&cid=47&id=1177&Itemid=166
Correct URL is: index.php?option=com_flexicontent&view=item&cid=47:categoryname&id=1177:itemname&Itemid=166
Now it's ok.