### PR TITLE
fix: fc_sef_lang should use current page language, no default

### DIFF
--- a/site/classes/helpers/html.php
+++ b/site/classes/helpers/html.php
@@ -1970,8 +1970,10 @@ class flexicontent_html
 			case 'flexi_js_common':
 
 				$site_languages = FLEXIUtilities::getLanguages();
-				$default_lang_code = flexicontent_html::getSiteDefaultLang();
-				$sef_lang_code = isset($site_languages->{$default_lang_code}) ? $site_languages->{$default_lang_code}->sef : '';
+  				$current_lang_code = flexicontent_html::getUserCurrentLang(false);
+  				$default_lang_code = flexicontent_html::getSiteDefaultLang();
+				$lang_code = isset($site_languages->{$current_lang_code}) ? $current_lang_code : $default_lang_code;
+				$sef_lang_code = isset($site_languages->{$lang_code}) ? $site_languages->{$lang_code}->sef : '';
 
 				$needed_vars = array('cid', 'cids', 'cc');
 				$FC_URL_VARS = array();


### PR DESCRIPTION
Problem:
  In components/com_flexicontent/classes/helpers/html.php, case 'flexi_js_common',
  the fc_sef_lang variable was computed via flexicontent_html::getSiteDefaultLang()
  (the site's global Default Language), instead of the currently active page
  language.

  var fc_sef_lang = '<site default sef>'; // e.g. 'en', even on /es/...

  This variable is passed to fcvote.js (and stateselector.js, fcfav.js,
  flexi-lib.js) as a &lang=... parameter on every FlexiContent AJAX request
  (voting, reviews, favorites, filters).

  Joomla's plg_system_languagefilter reads this parameter and switches the
  response language accordingly. On multilingual sites where the site's
  Default Language differs from the current page language, AJAX responses
  (FLEXI_THANK_YOU_FOR_VOTING, FLEXI_VOTE_YOUR_OLD_RATING_WAS_CHANGED,
  FLEXI_YOU_HAVE_ALREADY_VOTED, etc.) come back in the default language,
  ignoring the current language's translations/overrides (e.g.
  es-ES.override.ini).

  Fix:
  fc_sef_lang is now derived from flexicontent_html::getUserCurrentLang(false)
  (the language Joomla resolved for the current request), falling back to
  getSiteDefaultLang() if the current language is not registered in
  FlexiContent. Single-language sites are unaffected (current == default).