### PR TITLE
Fix silent failure when mediafile/file import source is missing

### DIFF
--- a/admin/controllers/import.php
+++ b/admin/controllers/import.php
@@ -1139,7 +1139,7 @@ class FlexicontentControllerImport extends FlexicontentControllerBaseAdmin
 		$dfolder  = \Joomla\Filesystem\Path::clean(JPATH_SITE . DS . $conf['docs_folder'] . DS);
 
 		$ff_types_to_props = array('image' => 'originalname', 'file' => '_value_', 'mediafile' => '_value_');
-		$ff_types_to_paths = array('image' => $mfolder, 'file' => $dfolder, 'mediafile' => $mfolder);
+		$ff_types_to_paths = array('image' => $mfolder, 'file' => $dfolder, 'mediafile' => $dfolder);
 		$ff_names_to_types = array();
 
 		foreach ($conf['custom_fields'] as $_fld)

--- a/plugins/flexicontent_fields/file/file.php
+++ b/plugins/flexicontent_fields/file/file.php
@@ -1412,6 +1412,15 @@ class plgFlexicontent_fieldsFile extends FCField
 						$upload_errs = null;
 						$file_ids = $fman->addlocal($Fobj, $upload_errs);
 
+						if (empty($file_ids))
+						{
+							\Joomla\CMS\Log\Log::add(
+								'file import: file "' . $filename . '" not found in folder "' . $import_docs_folder . $sub_folder . '"',
+								\Joomla\CMS\Log\Log::WARNING,
+								'com_flexicontent.importcsv'
+							);
+						}
+
 						// Get fist element
 						$v = !empty($file_ids) ? reset($file_ids) : ($use_ingroup ? null : false);
 						$v = $v ?: ($use_ingroup ? null : false);

--- a/plugins/flexicontent_fields/mediafile/mediafile.php
+++ b/plugins/flexicontent_fields/mediafile/mediafile.php
@@ -1439,6 +1439,15 @@ class plgFlexicontent_fieldsMediafile extends FCField
 					$upload_errs = null;
 					$file_ids = $fman->addlocal($Fobj, $upload_errs);
 
+					if (empty($file_ids))
+					{
+						\Joomla\CMS\Log\Log::add(
+							'mediafile import: file "' . $filename . '" not found in folder "' . $import_docs_folder . $sub_folder . '"',
+							\Joomla\CMS\Log\Log::WARNING,
+							'com_flexicontent.importcsv'
+						);
+					}
+
 					// Get fist element
 					$v = !empty($file_ids) ? reset($file_ids) : ($use_ingroup ? null : false);
 					$v = $v ?: ($use_ingroup ? null : false);


### PR DESCRIPTION
checkfiles() validated mediafile columns against media_folder, but the actual import logic in mediafile.php/file.php reads files from docs_folder, so a correctly-placed file could pass the pre-check while still being unreachable during the real import. When addlocal() then found no matching file, it failed completely silently - no warning, no log entry - leaving items saved without their files.

- checkfiles(): check 'mediafile' against docs_folder, matching the folder mediafile.php/file.php actually use (mediafile is a file field, not a media/gallery field)
- mediafile.php / file.php: log a warning to the importcsv log when addlocal() finds no matching file, instead of silently continuing